### PR TITLE
Add one-time login flow

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "require": "./test/mocha-init"
+}

--- a/app.coffee
+++ b/app.coffee
@@ -1,37 +1,35 @@
-Settings   = require "settings-sharelatex"
-logger     = require "logger-sharelatex"
-express    = require "express"
-bodyParser = require "body-parser"
-Metrics    = require "metrics-sharelatex"
-Path       = require "path"
+async = require "async"
+Settings = require "settings-sharelatex"
+logger = require "logger-sharelatex"
+express = require "express"
+Metrics = require "metrics-sharelatex"
+Path = require "path"
 
-HttpController = require "./app/js/HttpController"
-SessionMiddleware = require "./app/js/SessionMiddleware"
+EmailSender = require "./app/js/EmailSender"
+MongoHandler = require "./app/js/MongoHandler"
+Router = require "./app/js/Router"
 
 Metrics.initialize("read-only")
 logger.initialize("read-only")
+EmailSender.initialize()
 
 app = express()
-app.use(express.static('public'))
 app.set('views', __dirname + '/app/views')
 app.set('view engine', 'pug')
-
-app.use(SessionMiddleware.middleware)
-
-app.get '/', HttpController.home
-app.post "/login", bodyParser.urlencoded(), HttpController.login
-app.get "/project", HttpController.projects
-app.get "/project/:project_id", HttpController.getProject
-
-app.get '/status', (req, res)->
-	logger.log "hit status"
-	res.send('read-only is alive')
-
-smokeTest = require "smoke-test-sharelatex"
-app.get '/health_check', smokeTest.run(__dirname + "/test/smoke/js/test.js", 30000)
+Router.initialize(app)
 
 port = Settings.internal.read_only.port
 host = Settings.internal.read_only.host
-app.listen port, host, (error) ->
-	throw error if error?
-	logger.info "read-only starting up, listening on #{host}:#{port}"
+if !module.parent # Called directly
+	async.series {
+		initDb: (cb) ->
+			MongoHandler.initialize(cb)
+		startHttpServer: (cb) ->
+			logger.info("Starting HTTP server")
+			app.listen(port, host, cb)
+	}, (err) ->
+		if err?
+			throw err
+		logger.info("HTTP server ready and listening on #{host}:#{port}")
+
+module.exports = app

--- a/app/coffee/AuthController.coffee
+++ b/app/coffee/AuthController.coffee
@@ -1,0 +1,74 @@
+logger = require("logger-sharelatex")
+{ isCelebrate } = require('celebrate')
+
+AuthHandler = require("./AuthHandler")
+EmailHandler = require("./EmailHandler")
+Errors = require("./Errors")
+
+module.exports = AuthController =
+	login: (req, res, next) ->
+		{ email, password } = req.body
+		logger.info({ email }, "received password login request")
+		AuthHandler.login email, password, (err, userId) ->
+			if err?
+				return next(err)
+			logger.info({ email, userId }, "successful login")
+			req.session.user_id = userId
+			res.redirect("/project")
+
+	handleLoginErrors: (err, req, res, next) ->
+		if err instanceof Errors.AuthenticationError or isCelebrate(err)
+			res.render("home", { failedLogin: true })
+		else
+			next(err)
+
+	logout: (req, res, next) ->
+		req.session.destroy (err) ->
+			if err?
+				return next(err)
+			res.redirect("/")
+
+	oneTimeLogin: (req, res, next) ->
+		{ email, token } = req.query
+		logger.info({ email }, "received one-time login request")
+		AuthHandler.oneTimeLogin email, token, (err, userId) ->
+			if err?
+				return next(err)
+			logger.info({ email, userId }, "successful one-time login")
+			req.session.user_id = userId
+			res.redirect("/project")
+
+	handleOneTimeLoginErrors: (err, req, res, next) ->
+		if err instanceof Errors.AuthenticationError or isCelebrate(err)
+			res.render("home", { failedOneTimeLogin: true })
+		else
+			next(err)
+
+	oneTimeLoginRequestForm: (req, res, next) ->
+		res.render('one-time-login-request-form')
+
+	oneTimeLoginRequest: (req, res, next) ->
+		{ email } = req.body
+		AuthHandler.generateOneTimeLoginToken email, (err, token) ->
+			if err?
+				if err instanceof Errors.UserNotFoundError
+					res.render('one-time-login-request-form', {
+						error: "This email address is not registered in Overleaf",
+						email: email
+					})
+				else
+					next(err)
+			else
+				EmailHandler.sendOneTimeLoginEmail email, token, (err) ->
+					if err?
+						return next(err)
+					res.render('one-time-login-email-sent')
+
+	handleOneTimeLoginRequestErrors: (err, req, res, next) ->
+		if err instanceof Errors.UserNotFoundError or isCelebrate(err)
+			res.render('one-time-login-request-form', {
+				error: "This email address is not registered in Overleaf",
+				email: req.body.email
+			})
+		else
+			next(err)

--- a/app/coffee/AuthHandler.coffee
+++ b/app/coffee/AuthHandler.coffee
@@ -1,0 +1,93 @@
+_ = require("lodash")
+async = require("async")
+bcrypt = require("bcrypt")
+crypto = require("crypto")
+logger = require("logger-sharelatex")
+
+{ db } = require("./MongoHandler")
+Errors = require("./Errors")
+
+TOKEN_TTL_MS = 60 * 60 * 1000    # 1 hour
+TOKEN_SEARCH_PREFIX_LENGTH = 16  # 8 bytes
+
+module.exports = AuthHandler =
+	login: (email, password, callback) ->
+		db.users.findOne {email: email.toLowerCase()}, (err, user) ->
+			if err?
+				return callback(err)
+			if !user
+				return callback(new Errors.AuthenticationError("user not found"))
+			if !user.hashedPassword
+				return callback(new Errors.AuthenticationError("user does not have a password"))
+			bcrypt.compare password, user.hashedPassword, (err, match) ->
+				if err?
+					return callback(err)
+				if !match
+					return callback(new Errors.AuthenticationError("incorrect password"))
+				callback(null, user._id.toString())
+
+	oneTimeLogin: (email, token, callback) ->
+		now = new Date()
+		normalizedEmail = email.toLowerCase()
+		async.auto {
+			tokenDoc: (cb) =>
+				tokenPrefix = token.slice(0, TOKEN_SEARCH_PREFIX_LENGTH)
+				tokenPrefixRegexp = new RegExp("^#{_.escapeRegExp(tokenPrefix)}")
+				db.oneTimeLoginTokens.findOne({
+					email: normalizedEmail
+					token: tokenPrefixRegexp
+					expiresAt: { $gt: now }
+					usedAt: { $exists: false }
+				}, cb)
+			checkToken: ['tokenDoc', ({ tokenDoc }, cb) =>
+				if !tokenDoc
+					return cb(new Errors.AuthenticationError("invalid token"))
+				if !@_compareTokens(token, tokenDoc.token)
+					return cb(new Errors.AuthenticationError("invalid token"))
+				cb()
+			]
+			user: (cb) =>
+				db.users.findOne({ email: normalizedEmail }, cb)
+			checkUser: ['user', ({ user }, cb) =>
+				if !user?
+					return cb(new Errors.AuthenticationError("user not found"))
+				cb()
+			]
+			useToken: ['checkToken', 'checkUser', 'tokenDoc', ({ tokenDoc }, cb) =>
+				db.oneTimeLoginTokens.update({ _id: tokenDoc._id }, { $set: { usedAt: now } }, cb)
+			]
+		}, (err, { user }) =>
+			if err?
+				return callback(err)
+			callback(null, user._id.toString())
+
+	generateOneTimeLoginToken: (email, callback) ->
+		db.users.findOne { email: email.toLowerCase() }, (err, user) ->
+			if err?
+				return callback(err)
+			if !user?
+				return callback(new Errors.UserNotFoundError("user not found"))
+
+			logger.info({ email }, "Generating one-time login token")
+			now = new Date()
+			expiresAt = new Date(now.getTime() + TOKEN_TTL_MS)
+			token = crypto.randomBytes(32).toString('hex')
+			doc = {
+				email: email
+				token: token
+				createdAt: now
+				expiresAt: expiresAt
+			}
+			db.oneTimeLoginTokens.insert doc, (err) ->
+				if err?
+					return callback(err)
+				callback(null, token)
+
+	_compareTokens: (token1, token2) ->
+		token1Buffer = Buffer.from(token1)
+		token2Buffer = Buffer.from(token2)
+		if token1Buffer.length != token2Buffer.length
+			return false
+		if !crypto.timingSafeEqual(token1Buffer, token2Buffer)
+			return false
+		return true

--- a/app/coffee/EmailBuilder.coffee
+++ b/app/coffee/EmailBuilder.coffee
@@ -1,0 +1,46 @@
+marked = require("marked")
+Settings = require("settings-sharelatex")
+
+module.exports = {
+	buildPlainTextBody: (vars) ->
+		"""
+#{vars.message}
+
+#{vars.ctaText}: #{vars.ctaUrl}
+
+Regards,
+The Overleaf Team - #{Settings.siteUrl}
+"""
+
+	buildHtmlBody: (vars) ->
+		"""
+<table class="row" style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;">
+	<th class="small-12 large-12 columns first last" style="Margin: 0 auto; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 1.3; margin: 0 auto; padding: 0; padding-bottom: 16px; padding-left: 16px; padding-right: 16px; text-align: left; width: 564px;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><th style="Margin: 0; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 1.3; margin: 0; padding: 0; text-align: left;">
+			<h3 class="avoid-auto-linking" style="Margin: 0; color: #5D6879; font-family: Georgia, serif; font-size: 24px; font-weight: normal; line-height: 1.3; margin: 0; padding: 0; text-align: left; word-wrap: normal;">
+				#{vars.title}
+			</h3>
+		<table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="20px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: normal; hyphens: auto; line-height: 20px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+			<p style="Margin: 0; Margin-bottom: 10px; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 1.3; margin: 0; margin-bottom: 10px; padding: 0; text-align: left;">
+				Hi,
+			</p>
+		<p class="avoid-auto-linking" style="Margin: 0; Margin-bottom: 10px; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 1.3; margin: 0; margin-bottom: 10px; padding: 0; text-align: left;">
+			#{marked(vars.message)}
+		</p>
+		<table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="20px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: normal; hyphens: auto; line-height: 20px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+		<center data-parsed="" style="min-width: 532px; width: 100%;">
+			<table class="button float-center" style="Margin: 0 0 16px 0; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 0 16px 0; padding: 0; text-align: center; vertical-align: top; width: auto;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; border-radius: 9999px; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 1.3; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;"><table style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tr style="padding: 0; text-align: left; vertical-align: top;"><td style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; background: #4F9C45; border: none; border-collapse: collapse !important; border-radius: 9999px; color: #fefefe; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; hyphens: auto; line-height: 1.3; margin: 0; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">
+				<a href="#{vars.ctaUrl}" style="Margin: 0; border: 0 solid #4F9C45; border-radius: 9999px; color: #fefefe; display: inline-block; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: bold; line-height: 1.3; margin: 0; padding: 8px 16px 8px 16px; text-align: left; text-decoration: none;">
+					#{vars.ctaText}
+				</a>
+			</td></tr></table></td></tr></table>
+		</center>
+		<table class="spacer" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;"><tbody><tr style="padding: 0; text-align: left; vertical-align: top;"><td height="20px" style="-moz-hyphens: auto; -webkit-hyphens: auto; Margin: 0; border-collapse: collapse !important; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: normal; hyphens: auto; line-height: 20px; margin: 0; mso-line-height-rule: exactly; padding: 0; text-align: left; vertical-align: top; word-wrap: break-word;">&#xA0;</td></tr></tbody></table>
+		<p class="avoid-auto-linking" style="Margin: 0; Margin-bottom: 10px; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 12px; font-weight: normal; margin: 0; margin-bottom: 10px; padding: 0; text-align: left;">
+			If the button above does not appear, please open the link in your browser here:<br>
+			<a href="#{vars.ctaUrl}">#{vars.ctaUrl}</a>
+		</p>
+	</th>
+	<th class="expander" style="Margin: 0; color: #5D6879; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 1.3; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th></tr></table></th>
+</tr></tbody></table>
+"""
+}

--- a/app/coffee/EmailHandler.coffee
+++ b/app/coffee/EmailHandler.coffee
@@ -1,0 +1,37 @@
+Settings = require("settings-sharelatex")
+logger = require("logger-sharelatex")
+
+EmailBuilder = require("./EmailBuilder")
+EmailSender = require("./EmailSender")
+
+module.exports = EmailHandler = {
+	sendOneTimeLoginEmail: (email, token, callback) ->
+		logger.info({ email }, "Sending one-time login message")
+		templateVars = {
+			title: "Overleaf Read Only Access"
+			message: """
+The link below will log you into Overleaf's read only maintenance site, so you
+can download your projects.
+
+The link is valid for one hour or until the maintenance is finished.
+"""
+			ctaText: "Access my Projects"
+			ctaUrl: "#{Settings.siteUrl}/one-time-login?email=#{encodeURIComponent(email)}&token=#{encodeURIComponent(token)}"
+		}
+		textBody = EmailBuilder.buildPlainTextBody(templateVars)
+		htmlBody = EmailBuilder.buildHtmlBody(templateVars)
+		mailerParams = {
+			to: email
+			from: Settings.email.fromAddress
+			subject: "Overleaf Read Only Access"
+			text: textBody
+			html: htmlBody
+			replyTo: Settings.email.replyToAddress
+		}
+		EmailSender.sendMail mailerParams, (err) ->
+			if err?
+				logger.err({ err }, 'error sending email')
+				return callback(new Error('Cannot send mail'))
+			logger.info({ email }, "One-time login message sent")
+			callback()
+}

--- a/app/coffee/EmailSender.coffee
+++ b/app/coffee/EmailSender.coffee
@@ -1,0 +1,25 @@
+nodemailer = require("nodemailer")
+sengridTransport = require("nodemailer-sendgrid-transport")
+Settings = require("settings-sharelatex")
+logger = require('logger-sharelatex')
+
+mailer = null
+
+module.exports = {
+	initialize: () ->
+		switch Settings.email.transport
+			when "sendgrid"
+				logger.info("Configuring sendgrid mail transport")
+				mailer = nodemailer.createTransport(sendgridTransport(Settings.email.parameters))
+			when "smtp"
+				logger.info({ host: Settings.email.parameters.host }, "Configuring SMTP mail transport")
+				mailer = nodemailer.createTransport(Settings.email.parameters)
+			else
+				logger.info("No mail transport configured")
+
+	sendMail: (options, callback) ->
+		if !mailer?
+			logger.info({ recipient: options.to }, "Not sending email: transport not configured")
+			return callback()
+		mailer.sendMail(options, callback)
+}

--- a/app/coffee/Errors.coffee
+++ b/app/coffee/Errors.coffee
@@ -1,0 +1,17 @@
+AuthenticationError = (msg) ->
+	err = new Error(msg)
+	err.name = 'AuthenticationError'
+	err.__proto__ = AuthenticationError.prototype
+	return err
+AuthenticationError.prototype.__proto__ = Error.prototype
+
+module.exports.AuthenticationError = AuthenticationError
+
+UserNotFoundError = (msg) ->
+	err = new Error(msg)
+	err.name = 'UserNotFoundError'
+	err.__proto__ = UserNotFoundError.prototype
+	return err
+UserNotFoundError.prototype.__proto__ = Error.prototype
+
+module.exports.UserNotFoundError = UserNotFoundError

--- a/app/coffee/MongoHandler.coffee
+++ b/app/coffee/MongoHandler.coffee
@@ -1,0 +1,27 @@
+async = require "async"
+mongojs = require "mongojs"
+Settings = require "settings-sharelatex"
+logger = require "logger-sharelatex"
+
+module.exports = MongoHandler = {
+	db: mongojs(Settings.mongo.url, ["users", "projects", "oneTimeLoginTokens"])
+	ObjectId: mongojs.ObjectId
+
+	initialize: (callback) ->
+		logger.info("Initializing Mongo database")
+		async.series {
+			findUsersByEmail: (cb) =>
+				@db.users.ensureIndex({ email: 1 }, { background: true }, cb)
+			findTokensByEmail: (cb) =>
+				@db.oneTimeLoginTokens.ensureIndex({ email: 1 }, { background: true }, cb)
+			findProjectsByOwner: (cb) =>
+				@db.projects.ensureIndex({ owner_ref: 1 }, { background: true }, cb)
+			expireTokens: (cb) =>
+				@db.oneTimeLoginTokens.ensureIndex(
+					{ expiresAt: 1 },
+					{ background: true, expireAfterSeconds: 0 },
+					cb
+				)
+		}, (err) ->
+			callback(err)
+}

--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -1,0 +1,64 @@
+BodyParser = require("body-parser")
+{ celebrate, Joi } = require("celebrate")
+express = require("express")
+logger = require("logger-sharelatex")
+SmokeTest = require("smoke-test-sharelatex")
+
+AuthController = require "./AuthController"
+HttpController = require "./HttpController"
+SessionMiddleware = require "./SessionMiddleware"
+
+module.exports = Router =
+	initialize: (app) ->
+		app.use(express.static('public'))
+		app.use(SessionMiddleware.middleware)
+		app.use(BodyParser.urlencoded({ extended: false }))
+
+		app.get('/', HttpController.home)
+
+		app.post(
+			"/login",
+			celebrate({
+				body: Joi.object({
+					email: Joi.string().trim().email().required()
+					password: Joi.string().trim().required()
+				})
+			}),
+			AuthController.login,
+			AuthController.handleLoginErrors
+		)
+
+		app.get("/logout", AuthController.logout)
+		app.get("/one-time-login/request", AuthController.oneTimeLoginRequestForm)
+
+		app.post(
+			"/one-time-login/request",
+			celebrate({
+				body: Joi.object({
+					email: Joi.string().trim().email().required()
+				})
+			}),
+			AuthController.oneTimeLoginRequest,
+			AuthController.handleOneTimeLoginRequestErrors
+		)
+
+		app.get(
+			"/one-time-login",
+			celebrate({
+				query: Joi.object({
+					email: Joi.string().email().required()
+					token: Joi.string().regex(/^[0-9a-f]{64}$/, 'token').required()
+				})
+			})
+			AuthController.oneTimeLogin,
+			AuthController.handleOneTimeLoginErrors
+		)
+
+		app.get("/project", HttpController.projects)
+		app.get("/project/:project_id", HttpController.getProject)
+
+		app.get '/status', (req, res)->
+			logger.log "hit status"
+			res.send('read-only is alive')
+
+		app.get '/health_check', SmokeTest.run(__dirname + "/test/smoke/js/test.js", 30000)

--- a/app/coffee/SessionMiddleware.coffee
+++ b/app/coffee/SessionMiddleware.coffee
@@ -2,9 +2,12 @@ Settings = require("settings-sharelatex")
 session = require("express-session")
 MongoStore = require('connect-mongo')(session)
 
+SESSION_TTL_SECS = 60 * 60   # 1 hour
+
 sessionStore = new MongoStore({
 	url: Settings.mongo.url
 	collection: "sessions"
+	ttl: SESSION_TTL_SECS
 })
 
 middleware = session({

--- a/app/coffee/mongojs.coffee
+++ b/app/coffee/mongojs.coffee
@@ -1,7 +1,0 @@
-Settings = require "settings-sharelatex"
-mongojs = require "mongojs"
-db = mongojs(Settings.mongo.url, ["users", "projects"])
-module.exports =
-	db: db
-	ObjectId: mongojs.ObjectId
-

--- a/app/views/home.pug
+++ b/app/views/home.pug
@@ -7,8 +7,14 @@ block content
 			.col-md-6.col-md-offset-3
 				.card
 					form(action="/login", method="POST")
-						if failedLogIn
+						if failedLogin
 							.alert.alert-danger Your email or password was incorrect
+						if failedOneTimeLogin
+							.alert.alert-danger
+								| Your login link has expired. Please
+								|
+								a(href="/one-time-login/request") request another one
+								| .
 						.form-group
 							label(for='email') Email
 							input.form-control(
@@ -27,8 +33,7 @@ block content
 								placeholder='********'
 							)
 						.actions
-							button.btn-primary.btn(
-								type='submit'
-							) Log in
-
-						
+							a.btn.btn-link.pull-right(href="/one-time-login/request")
+								| Forgot your password or don't have one?
+							button.btn-primary.btn(type='submit')
+								| Log in

--- a/app/views/one-time-login-email-sent.pug
+++ b/app/views/one-time-login-email-sent.pug
@@ -1,0 +1,13 @@
+extends ./layout
+
+block content
+	.container
+		.row-spaced
+		.row
+			.col-md-6.col-md-offset-3
+				.card
+					p
+						| We have sent you an email with a link that will log
+						| you into Overleaf's read only maintenance site, so
+						| you can download your projects. Please check your
+						| inbox and spam folder.

--- a/app/views/one-time-login-request-form.pug
+++ b/app/views/one-time-login-request-form.pug
@@ -1,0 +1,28 @@
+extends ./layout
+
+block content
+	.container
+		.row-spaced
+		.row
+			.col-md-6.col-md-offset-3
+				.card
+					p
+						| Please enter your email below, and we'll send you a
+						| link that will log you into Overleaf's read only
+						| maintenance site, so you can download your projects.
+					form(action="/one-time-login/request", method="POST")
+						if error
+							.alert.alert-danger #{error}
+						.form-group
+							label(for='email') Email
+							input.form-control(
+								type='email',
+								name='email',
+								value=email
+								required,
+								placeholder='email@example.com',
+								autofocus
+							)
+						.actions
+							button.btn-primary.btn(type='submit')
+								| Send login link

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -4,12 +4,27 @@ http.globalAgent.maxSockets = 300
 MONGO_HOST = process.env['MONGO_HOST'] or "localhost"
 MONGO_URL = process.env['MONGO_URL'] or "mongodb://#{MONGO_HOST}/read_only"
 PROJECT_ARCHIVER_HOST = process.env['PROJECT_ARCHIVER_HOST'] or "localhost"
+HOST_LISTEN_PORT = process.env['HOST_LISTEN_PORT'] or 3038
+
+emailTransportParams = switch process.env['EMAIL_TRANSPORT']
+	when "sendgrid" then {
+		auth:
+			api_key: process.env['SENDGRID_API_KEY']
+	}
+	when "smtp" then {
+		host: process.env['SMTP_HOST']
+		port: process.env['SMTP_PORT'] or 25
+		auth:
+			user: process.env['SMTP_USER']
+			pass: process.env['SMTP_PASS']
+	}
+	else {}
 
 module.exports =
 	internal:
 		read_only:
 			host: process.env['LISTEN_ADDRESS'] or "localhost"
-			port: process.env['HOST_LISTEN_PORT'] or 3038
+			port: HOST_LISTEN_PORT
 
 	apis:
 		project_archiver:
@@ -24,3 +39,10 @@ module.exports =
 	behindProxy: false
 	security:
 		sessionSecret: "banana"
+
+	email:
+		fromAddress: "Overleaf <welcome@overleaf.com>"
+		replyToAddress: "welcome@overleaf.com"
+		transport: process.env['EMAIL_TRANSPORT']
+		parameters: emailTransportParams
+	siteUrl: process.env['PUBLIC_URL'] or "http://localhost:#{HOST_LISTEN_PORT}"

--- a/config/settings.test.coffee
+++ b/config/settings.test.coffee
@@ -1,0 +1,7 @@
+module.exports =
+	email:
+		transport: 'smtp'
+		parameters:
+			host: 'localhost'
+			port: 1025
+			ignoreTLS: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,91 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/hoek": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+    },
+    "@hapi/joi": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
+      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/marker": "1.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/marker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
+      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
+      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
+          "integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw=="
+        }
+      }
+    },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/babel-types": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
@@ -16,6 +101,12 @@
       "requires": {
         "@types/babel-types": "*"
       }
+    },
+    "abab": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -50,6 +141,24 @@
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
       }
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+      "dev": true
+    },
+    "addressparser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y=",
+      "dev": true
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
     },
     "ajv": {
       "version": "6.10.0",
@@ -98,6 +207,12 @@
           }
         }
       }
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -148,6 +263,15 @@
         "readable-stream": "^2.0.6"
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -166,15 +290,33 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
       "dev": true
     },
     "asap": {
@@ -196,9 +338,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
-      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -208,14 +350,20 @@
       "dev": true
     },
     "async": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
-      "integrity": "sha1-7mXsdymML/FFa8RBigUtDwZDURI="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
     },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -263,6 +411,12 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -330,6 +484,18 @@
         }
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "dev": true
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "dev": true
+    },
     "bcrypt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-3.0.6.tgz",
@@ -347,10 +513,25 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true
+    },
+    "blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
     "body-parser": {
@@ -457,6 +638,18 @@
         }
       }
     },
+    "browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "bson": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
@@ -486,21 +679,6 @@
         }
       }
     },
-    "buster-core": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/buster-core/-/buster-core-0.6.4.tgz",
-      "integrity": "sha1-J79rrWdCROpyDzEdkAoMoct4YFA=",
-      "dev": true
-    },
-    "buster-format": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/buster-format/-/buster-format-0.5.6.tgz",
-      "integrity": "sha1-K4bDIuz14bCubm55Bev884fSq5U=",
-      "dev": true,
-      "requires": {
-        "buster-core": "=0.6.4"
-      }
-    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -523,6 +701,12 @@
         "unset-value": "^1.0.0"
       }
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -539,6 +723,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "celebrate": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-10.0.1.tgz",
+      "integrity": "sha512-Eke/caDOlcLjwk8WN4+bX9WyiiIgJ+zjbsh368FAtEj74bNC3Y+gVfFF8efmP9iYVnFSkLy31+6bKCQm/Zza+g==",
+      "requires": {
+        "@hapi/joi": "15.x.x",
+        "escape-html": "1.0.3"
+      }
+    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -549,13 +742,17 @@
       }
     },
     "chai": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
-      "integrity": "sha1-Pxog+CsLnXQ3V30k1vErGmnTtZA=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.0",
-        "deep-eql": "0.1.3"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -576,6 +773,12 @@
       "requires": {
         "is-regex": "^1.0.3"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "2.1.6",
@@ -703,10 +906,31 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "concat-map": {
@@ -855,12 +1079,38 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "cssom": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+      "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
       }
     },
     "debug": {
@@ -883,18 +1133,33 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -968,10 +1233,25 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "doctypes": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -1024,10 +1304,189 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "engine.io": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
+      "integrity": "sha1-jef5eJXSDTm4X4ju7nd7K9QrE9Q=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "ws": "1.1.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.11",
+            "negotiator": "0.6.1"
+          }
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+          "dev": true
+        },
+        "ws": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
+          "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
+          "dev": true,
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
+      "integrity": "sha1-F5jtk0USRkU9TG9jXXogH+lA1as=",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "1.1.2",
+        "xmlhttprequest-ssl": "1.5.3",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
+        "ws": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
+          "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
+          "dev": true,
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.7",
+        "wtf-8": "1.0.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "es6-promise": {
       "version": "3.2.1",
@@ -1043,6 +1502,39 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -1324,6 +1816,12 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1368,6 +1866,32 @@
           "requires": {
             "ms": "2.0.0"
           }
+        }
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
         }
       }
     },
@@ -2002,6 +2526,18 @@
         }
       }
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -2089,6 +2625,18 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
       "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2111,10 +2659,39 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-binary": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-unicode": {
@@ -2152,6 +2729,21 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "http-errors": {
@@ -2210,6 +2802,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2229,10 +2827,28 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+    },
+    "ipv6-normalize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ipv6-normalize/-/ipv6-normalize-1.0.1.tgz",
+      "integrity": "sha1-GzJYKQ02X6gyOeiZB93kWS52IKg=",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -2257,6 +2873,12 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
     "is-ci": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -2274,6 +2896,12 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -2419,6 +3047,15 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -2457,10 +3094,89 @@
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.1.1.tgz",
+      "integrity": "sha512-cQZRBB33arrDAeCrAEWn1U3SvrvC8XysBua9Oqg1yWrsY/gYcusloJC3RZJXuY5eehSCmws8f2YeliCqGSkrtQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "acorn": "^6.1.1",
+        "acorn-globals": "^4.3.2",
+        "array-equal": "^1.0.0",
+        "cssom": "^0.3.6",
+        "cssstyle": "^1.2.2",
+        "data-urls": "^1.1.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.11.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "nwsapi": "^2.1.4",
+        "parse5": "5.1.0",
+        "pn": "^1.1.0",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.7",
+        "saxes": "^3.1.9",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^3.0.1",
+        "w3c-hr-time": "^1.0.1",
+        "w3c-xmlserializer": "^1.1.2",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^7.0.0",
+        "ws": "^7.0.0",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+          "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^6.0.1",
+            "acorn-walk": "^6.0.1"
+          }
+        },
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2476,6 +3192,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2496,6 +3218,12 @@
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
       }
+    },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
@@ -2519,10 +3247,54 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
     },
     "logger-sharelatex": {
       "version": "git+https://github.com/sharelatex/logger-sharelatex.git#5a3ea8e655f23e76a77bbc207c012d3fc944c8d8",
@@ -2544,6 +3316,12 @@
           }
         }
       }
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -2575,6 +3353,282 @@
         "statsd-parser": "~0.0.4"
       }
     },
+    "maildev": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/maildev/-/maildev-1.0.0.tgz",
+      "integrity": "sha512-7vkKY0Kb29ApnQoI+D0uJO3seuGE43/bvoJOcmC6QFcIdtMU/VWPyjgLseVJyfuKfpaR5in/vmxpW8Je0tOMGA==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.1",
+        "commander": "2.9.0",
+        "express": "4.13.4",
+        "mailparser": "0.6.2",
+        "open": "0.0.5",
+        "rimraf": "^2.6.1",
+        "smtp-connection": "2.3.1",
+        "smtp-server": "1.16.1",
+        "socket.io": "1.7.3",
+        "wildstring": "1.0.8"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+          "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.6",
+            "negotiator": "0.5.3"
+          }
+        },
+        "async": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz",
+          "integrity": "sha1-sFcU9LEbNXv3mtr/3QbaQtB2bBA=",
+          "dev": true
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+          "integrity": "sha1-h0dsamfI2qh+Muh2Ft+IO6f7Bxs=",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+          "integrity": "sha1-armUiksa4hlSzSWIUwpHItQETXw=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "etag": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
+          "dev": true
+        },
+        "express": {
+          "version": "4.13.4",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+          "integrity": "sha1-PAt288d1kMg0VzkGHsC9O6Bn7CQ=",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.2.12",
+            "array-flatten": "1.1.1",
+            "content-disposition": "0.5.1",
+            "content-type": "~1.0.1",
+            "cookie": "0.1.5",
+            "cookie-signature": "1.0.6",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
+            "finalhandler": "0.4.1",
+            "fresh": "0.3.0",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.1",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~1.0.10",
+            "qs": "4.0.0",
+            "range-parser": "~1.0.3",
+            "send": "0.13.1",
+            "serve-static": "~1.10.2",
+            "type-is": "~1.6.6",
+            "utils-merge": "1.0.0",
+            "vary": "~1.0.1"
+          }
+        },
+        "finalhandler": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
+          "dev": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "statuses": "1"
+          }
+        },
+        "ipaddr.js": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+          "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+          "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
+          "dev": true
+        },
+        "proxy-addr": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+          "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+          "dev": true,
+          "requires": {
+            "forwarded": "~0.1.0",
+            "ipaddr.js": "1.0.5"
+          }
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+          "dev": true
+        },
+        "range-parser": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+          "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "send": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "integrity": "sha1-ow1fTILIqbrprQCh2bG9vm8Zntc=",
+          "dev": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "destroy": "~1.0.4",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
+            "fresh": "0.3.0",
+            "http-errors": "~1.3.1",
+            "mime": "1.3.4",
+            "ms": "0.7.1",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.0.3",
+            "statuses": "~1.2.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+          "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+          "dev": true,
+          "requires": {
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.1",
+            "send": "0.13.2"
+          },
+          "dependencies": {
+            "send": {
+              "version": "0.13.2",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+              "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
+              "dev": true,
+              "requires": {
+                "debug": "~2.2.0",
+                "depd": "~1.1.0",
+                "destroy": "~1.0.4",
+                "escape-html": "~1.0.3",
+                "etag": "~1.7.0",
+                "fresh": "0.3.0",
+                "http-errors": "~1.3.1",
+                "mime": "1.3.4",
+                "ms": "0.7.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.0.3",
+                "statuses": "~1.2.1"
+              }
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
+          "dev": true
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+          "dev": true
+        },
+        "vary": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+          "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA=",
+          "dev": true
+        }
+      }
+    },
+    "mailparser": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.6.2.tgz",
+      "integrity": "sha1-A8SGA5vfTfbNO2rcqqxBB9/bwGg=",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.12",
+        "mime": "^1.3.4",
+        "mimelib": "^0.3.0",
+        "uue": "^3.1.0"
+      }
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -2582,6 +3636,15 @@
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -2599,10 +3662,26 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
     },
     "memory-pager": {
       "version": "1.5.0",
@@ -2688,6 +3767,22 @@
         "mime-db": "1.40.0"
       }
     },
+    "mimelib": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.3.1.tgz",
+      "integrity": "sha1-eHrdJBXYJ6yzr27EvKHqlZZBiFM=",
+      "dev": true,
+      "requires": {
+        "addressparser": "~1.0.1",
+        "encoding": "~0.1.12"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2752,6 +3847,153 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
+      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.0.0"
+          }
+        }
       }
     },
     "mongodb": {
@@ -2974,6 +4216,60 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
     "node-pre-gyp": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
@@ -3027,6 +4323,34 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "nodemailer": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.2.1.tgz",
+      "integrity": "sha512-TagB7iuIi9uyNgHExo8lUDq3VK5/B0BpbkcjIgNvxbtVrjNqq0DwAOTuzALPVkK76kMhTSzIgHqg8X1uklVs6g=="
+    },
+    "nodemailer-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.3.0.tgz",
+      "integrity": "sha1-nzf2pbgMHLXWl8or+95BplgqULA=",
+      "dev": true
+    },
+    "nodemailer-sendgrid-transport": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-sendgrid-transport/-/nodemailer-sendgrid-transport-0.2.0.tgz",
+      "integrity": "sha1-pRZZO/49HyeM/hcGDh2yNlio9Pw=",
+      "requires": {
+        "sendgrid": "^1.8.0"
+      }
+    },
+    "nodemailer-shared": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.0.4.tgz",
+      "integrity": "sha1-i1xcNb+ymkfdp9ODA/Ok+0e6OK4=",
+      "dev": true,
+      "requires": {
+        "nodemailer-fetch": "1.3.0"
+      }
     },
     "nodemon": {
       "version": "1.19.1",
@@ -3100,6 +4424,12 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "nwsapi": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+      "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -3109,6 +4439,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -3132,6 +4468,12 @@
         }
       }
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -3139,6 +4481,28 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -3171,10 +4535,94 @@
         "wrappy": "1"
       }
     },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "dev": true
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -3190,10 +4638,46 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "package-json": {
@@ -3213,6 +4697,33 @@
       "resolved": "https://registry.npmjs.org/parse-mongo-url/-/parse-mongo-url-1.1.1.tgz",
       "integrity": "sha1-ZiON9fjnwMjKTNlw1KtqE3PrdbU="
     },
+    "parsejson": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3228,6 +4739,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
@@ -3257,6 +4774,12 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3268,10 +4791,22 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
@@ -3432,6 +4967,16 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
       "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -3638,10 +5183,42 @@
         }
       }
     },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
     "require-like": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
       "integrity": "sha1-rW8wwTvs15cBDEaK+ndcDAprR/o=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "require_optional": {
@@ -3721,19 +5298,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sandboxed-module": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/sandboxed-module/-/sandboxed-module-0.3.0.tgz",
-      "integrity": "sha1-8fvvvYCaT2kHO9B8rm/H2y6vX2o=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sandboxed-module/-/sandboxed-module-2.0.3.tgz",
+      "integrity": "sha1-x+VFkzm7y6KMUwPusz9ug4e/upY=",
       "dev": true,
       "requires": {
         "require-like": "0.1.2",
-        "stack-trace": "0.0.6"
+        "stack-trace": "0.0.9"
       },
       "dependencies": {
         "stack-trace": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.6.tgz",
-          "integrity": "sha1-HnGb1qJin/CcGJ4Xqe+QKpT8XbA=",
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+          "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
           "dev": true
         }
       }
@@ -3751,6 +5328,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "saxes": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.1.1"
+      }
     },
     "semver": {
       "version": "5.5.0",
@@ -3805,6 +5391,24 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "sendgrid": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/sendgrid/-/sendgrid-1.9.2.tgz",
+      "integrity": "sha1-1AfmogawoqaWQkbdnAZBwQvwLxk=",
+      "requires": {
+        "lodash": "^3.0.1 || ^2.0.0",
+        "mime": "^1.2.9",
+        "request": "^2.60.0",
+        "smtpapi": "^1.2.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
@@ -3892,13 +5496,25 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.5.2.tgz",
-      "integrity": "sha1-nKvGx4vfRF1/gxHVSWhi+VRoxPg=",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
       "dev": true,
       "requires": {
-        "buster-format": "~0.5"
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
       }
+    },
+    "sinon-chai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "dev": true
     },
     "smoke-test-sharelatex": {
       "version": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#bc3e93d18ccee219c0d99e8b02c984ccdd842e1c",
@@ -3982,6 +5598,47 @@
           }
         }
       }
+    },
+    "smtp-connection": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.3.1.tgz",
+      "integrity": "sha1-0WnI8cmnOFQTTNq+b7gYI338T7o=",
+      "dev": true,
+      "requires": {
+        "nodemailer-shared": "1.0.4"
+      }
+    },
+    "smtp-server": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-1.16.1.tgz",
+      "integrity": "sha1-kdLb1ei7ntOVsaF3Totg3Xsk5FM=",
+      "dev": true,
+      "requires": {
+        "ipv6-normalize": "^1.0.1",
+        "nodemailer-shared": "^1.1.0"
+      },
+      "dependencies": {
+        "nodemailer-fetch": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
+          "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
+          "dev": true
+        },
+        "nodemailer-shared": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
+          "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
+          "dev": true,
+          "requires": {
+            "nodemailer-fetch": "1.6.0"
+          }
+        }
+      }
+    },
+    "smtpapi": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/smtpapi/-/smtpapi-1.3.1.tgz",
+      "integrity": "sha1-GHQp607SffSjz/0j8OAkXN/mh9Q="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -4100,6 +5757,154 @@
         "kind-of": "^3.2.0"
       }
     },
+    "socket.io": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
+      "integrity": "sha1-uK+cq6AJSeVo42nxMn6pvp6iRhs=",
+      "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "engine.io": "1.8.3",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.7.3",
+        "socket.io-parser": "2.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
+      "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-client": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
+      "integrity": "sha1-sw6GqhDV7zVGYBwJzeR2Xjgdo3c=",
+      "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "1.8.3",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4141,6 +5946,12 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -4193,6 +6004,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
@@ -4251,6 +6068,12 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "tar": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
@@ -4296,6 +6119,12 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-0.0.5.tgz",
       "integrity": "sha1-DKbnGM5O8RhHfJETmja7u2+gHB0=",
+      "dev": true
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
     "to-fast-properties": {
@@ -4374,6 +6203,15 @@
         }
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4387,10 +6225,19 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-is": {
@@ -4432,6 +6279,12 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+      "dev": true
     },
     "undefsafe": {
       "version": "2.0.2",
@@ -4616,6 +6469,16 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "uue": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/uue/-/uue-3.1.2.tgz",
+      "integrity": "sha512-axKLXVqwtdI/czrjG0X8hyV1KLgeWx8F4KvSbvVCnS+RUvsQMGRjx0kfuZDXXqj0LYvVJmx3B9kWlKtEdRrJLg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "~1.0.5",
+        "extend": "~3.0.0"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4636,6 +6499,58 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+      "dev": true,
+      "requires": {
+        "domexception": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+      "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4644,6 +6559,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
@@ -4680,6 +6601,12 @@
         }
       }
     },
+    "wildstring": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/wildstring/-/wildstring-1.0.8.tgz",
+      "integrity": "sha1-gLX4W3+KqYvBnMIw5grH9eDdIm0=",
+      "dev": true
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -4698,6 +6625,27 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -4723,16 +6671,55 @@
         }
       }
     },
+    "ws": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
+      "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "^1.0.0"
+      }
+    },
+    "wtf-8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
+      "dev": true
+    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.1.1.tgz",
+      "integrity": "sha512-7hew1RPJ1iIuje/Y01bGD/mXokXxegAgVS+e+E0wSi2ILHQkYAH1+JXARwTjZSM4Z4Z+c73aKspEcqj+zPPL/w==",
+      "dev": true
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
+      "dev": true
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
     },
     "yallist": {
       "version": "3.0.3",
@@ -4749,6 +6736,118 @@
         "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,28 +17,36 @@
     "nodemon": "nodemon --config nodemon.json"
   },
   "dependencies": {
-    "async": "~0.8.0",
+    "async": "^3.1.0",
     "bcrypt": "^3.0.6",
     "body-parser": "^1.19.0",
+    "celebrate": "^10.0.1",
     "coffeescript": "^1.12.7",
     "connect-mongo": "^3.0.0",
     "express": "^4.17.1",
     "express-session": "^1.12.1",
+    "lodash": "^4.17.11",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.1.0",
+    "marked": "^0.6.2",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.1.0",
     "mongojs": "2.4.0",
+    "nodemailer": "^6.2.1",
+    "nodemailer-sendgrid-transport": "^0.2.0",
     "pug": "^2.0.4",
     "request": "^2.88.0",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
-    "smoke-test-sharelatex": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#master",
-    "underscore": "~1.6.0"
+    "smoke-test-sharelatex": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#master"
   },
   "devDependencies": {
     "bunyan": "~0.22.3",
-    "chai": "~1.9.1",
+    "chai": "^4.2.0",
+    "jsdom": "^15.1.1",
+    "maildev": "^1.0.0",
+    "mocha": "^6.1.4",
     "nodemon": "^1.19.1",
-    "sandboxed-module": "~0.3.0",
-    "sinon": "~1.5.2",
+    "sandboxed-module": "^2.0.3",
+    "sinon": "^7.3.2",
+    "sinon-chai": "^3.3.0",
     "timekeeper": "0.0.5"
   }
 }

--- a/public/main.css
+++ b/public/main.css
@@ -4077,3 +4077,431 @@ footer.site-footer a:focus {
 .nav-pills > li > a {
   border-radius: 9999px;
 }
+
+.alert {
+  padding: 15px;
+  margin-bottom: 25px;
+  border-left: 3px solid transparent;
+  border-radius: 3px;
+}
+.alert h4 {
+  margin-top: 0;
+  color: inherit;
+}
+.alert .alert-link {
+  font-weight: bold;
+}
+.alert > p,
+.alert > ul {
+  margin-bottom: 0;
+}
+.alert > p + p {
+  margin-top: 5px;
+}
+.alert-dismissable {
+  padding-right: 35px;
+}
+.alert-dismissable .close {
+  position: relative;
+  top: -2px;
+  right: -21px;
+  color: inherit;
+}
+.alert-success {
+  background-color: #46a546;
+  border-color: transparent;
+  color: #FFF;
+}
+.alert-success hr {
+  border-top-color: rgba(0, 0, 0, 0);
+}
+.alert-success .alert-link {
+  color: #e6e6e6;
+}
+.alert-success .alert-link-as-btn {
+  display: inline-block;
+  font-weight: bold;
+  text-decoration: none;
+  color: #FFF;
+  background-color: #388438;
+  border-color: transparent;
+  padding: 0px 10px 1px;
+  font-size: 14px;
+  line-height: 1.5;
+  border-radius: 9999px;
+}
+.alert .alert-success .alert-link-as-btn {
+  background-color: #204b20;
+}
+.alert-success .alert-link-as-btn:hover,
+.alert-success .alert-link-as-btn:focus,
+.alert-success .alert-link-as-btn:active,
+.alert-success .alert-link-as-btn.active,
+.alert-success .alert-link-as-btn.checked,
+.open .dropdown-toggle.alert-success .alert-link-as-btn {
+  color: #FFF;
+  background-color: #2c672c;
+  border-color: rgba(0, 0, 0, 0);
+}
+.alert .alert-success .alert-link-as-btn:hover,
+.alert .alert-success .alert-link-as-btn:focus,
+.alert .alert-success .alert-link-as-btn:active,
+.alert .alert-success .alert-link-as-btn.active,
+.alert .alert-success .alert-link-as-btn.checked,
+.alert .open .dropdown-toggle.alert-success .alert-link-as-btn {
+  background-color: #142e14;
+}
+.alert-success .alert-link-as-btn:active,
+.alert-success .alert-link-as-btn.active,
+.open .dropdown-toggle.alert-success .alert-link-as-btn {
+  background-image: none;
+}
+.alert-success .alert-link-as-btn.disabled,
+.alert-success .alert-link-as-btn[disabled],
+fieldset[disabled] .alert-success .alert-link-as-btn,
+.alert-success .alert-link-as-btn.disabled:hover,
+.alert-success .alert-link-as-btn[disabled]:hover,
+fieldset[disabled] .alert-success .alert-link-as-btn:hover,
+.alert-success .alert-link-as-btn.disabled:focus,
+.alert-success .alert-link-as-btn[disabled]:focus,
+fieldset[disabled] .alert-success .alert-link-as-btn:focus,
+.alert-success .alert-link-as-btn.disabled:active,
+.alert-success .alert-link-as-btn[disabled]:active,
+fieldset[disabled] .alert-success .alert-link-as-btn:active,
+.alert-success .alert-link-as-btn.disabled.active,
+.alert-success .alert-link-as-btn[disabled].active,
+fieldset[disabled] .alert-success .alert-link-as-btn.active {
+  background-color: #388438;
+  border-color: transparent;
+}
+.alert-success .alert-link-as-btn .badge {
+  color: #388438;
+  background-color: #FFF;
+}
+.alert-success .alert-link-as-btn:hover {
+  text-decoration: none;
+}
+.alert-success small,
+.alert-success .small {
+  color: #FFF;
+}
+.alert-info {
+  background-color: #3E70BB;
+  border-color: transparent;
+  color: #FFF;
+}
+.alert-info hr {
+  border-top-color: rgba(0, 0, 0, 0);
+}
+.alert-info .alert-link {
+  color: #e6e6e6;
+}
+.alert-info .alert-link-as-btn {
+  display: inline-block;
+  font-weight: bold;
+  text-decoration: none;
+  color: #FFF;
+  background-color: #325a96;
+  border-color: transparent;
+  padding: 0px 10px 1px;
+  font-size: 14px;
+  line-height: 1.5;
+  border-radius: 9999px;
+}
+.alert .alert-info .alert-link-as-btn {
+  background-color: #1d3558;
+}
+.alert-info .alert-link-as-btn:hover,
+.alert-info .alert-link-as-btn:focus,
+.alert-info .alert-link-as-btn:active,
+.alert-info .alert-link-as-btn.active,
+.alert-info .alert-link-as-btn.checked,
+.open .dropdown-toggle.alert-info .alert-link-as-btn {
+  color: #FFF;
+  background-color: #274777;
+  border-color: rgba(0, 0, 0, 0);
+}
+.alert .alert-info .alert-link-as-btn:hover,
+.alert .alert-info .alert-link-as-btn:focus,
+.alert .alert-info .alert-link-as-btn:active,
+.alert .alert-info .alert-link-as-btn.active,
+.alert .alert-info .alert-link-as-btn.checked,
+.alert .open .dropdown-toggle.alert-info .alert-link-as-btn {
+  background-color: #13233a;
+}
+.alert-info .alert-link-as-btn:active,
+.alert-info .alert-link-as-btn.active,
+.open .dropdown-toggle.alert-info .alert-link-as-btn {
+  background-image: none;
+}
+.alert-info .alert-link-as-btn.disabled,
+.alert-info .alert-link-as-btn[disabled],
+fieldset[disabled] .alert-info .alert-link-as-btn,
+.alert-info .alert-link-as-btn.disabled:hover,
+.alert-info .alert-link-as-btn[disabled]:hover,
+fieldset[disabled] .alert-info .alert-link-as-btn:hover,
+.alert-info .alert-link-as-btn.disabled:focus,
+.alert-info .alert-link-as-btn[disabled]:focus,
+fieldset[disabled] .alert-info .alert-link-as-btn:focus,
+.alert-info .alert-link-as-btn.disabled:active,
+.alert-info .alert-link-as-btn[disabled]:active,
+fieldset[disabled] .alert-info .alert-link-as-btn:active,
+.alert-info .alert-link-as-btn.disabled.active,
+.alert-info .alert-link-as-btn[disabled].active,
+fieldset[disabled] .alert-info .alert-link-as-btn.active {
+  background-color: #325a96;
+  border-color: transparent;
+}
+.alert-info .alert-link-as-btn .badge {
+  color: #325a96;
+  background-color: #FFF;
+}
+.alert-info .alert-link-as-btn:hover {
+  text-decoration: none;
+}
+.alert-info small,
+.alert-info .small {
+  color: #FFF;
+}
+.alert-warning {
+  background-color: #f89406;
+  border-color: transparent;
+  color: #FFF;
+}
+.alert-warning hr {
+  border-top-color: rgba(0, 0, 0, 0);
+}
+.alert-warning .alert-link {
+  color: #e6e6e6;
+}
+.alert-warning .alert-link-as-btn {
+  display: inline-block;
+  font-weight: bold;
+  text-decoration: none;
+  color: #FFF;
+  background-color: #c67605;
+  border-color: transparent;
+  padding: 0px 10px 1px;
+  font-size: 14px;
+  line-height: 1.5;
+  border-radius: 9999px;
+}
+.alert .alert-warning .alert-link-as-btn {
+  background-color: #774703;
+}
+.alert-warning .alert-link-as-btn:hover,
+.alert-warning .alert-link-as-btn:focus,
+.alert-warning .alert-link-as-btn:active,
+.alert-warning .alert-link-as-btn.active,
+.alert-warning .alert-link-as-btn.checked,
+.open .dropdown-toggle.alert-warning .alert-link-as-btn {
+  color: #FFF;
+  background-color: #9f5f04;
+  border-color: rgba(0, 0, 0, 0);
+}
+.alert .alert-warning .alert-link-as-btn:hover,
+.alert .alert-warning .alert-link-as-btn:focus,
+.alert .alert-warning .alert-link-as-btn:active,
+.alert .alert-warning .alert-link-as-btn.active,
+.alert .alert-warning .alert-link-as-btn.checked,
+.alert .open .dropdown-toggle.alert-warning .alert-link-as-btn {
+  background-color: #4f2f02;
+}
+.alert-warning .alert-link-as-btn:active,
+.alert-warning .alert-link-as-btn.active,
+.open .dropdown-toggle.alert-warning .alert-link-as-btn {
+  background-image: none;
+}
+.alert-warning .alert-link-as-btn.disabled,
+.alert-warning .alert-link-as-btn[disabled],
+fieldset[disabled] .alert-warning .alert-link-as-btn,
+.alert-warning .alert-link-as-btn.disabled:hover,
+.alert-warning .alert-link-as-btn[disabled]:hover,
+fieldset[disabled] .alert-warning .alert-link-as-btn:hover,
+.alert-warning .alert-link-as-btn.disabled:focus,
+.alert-warning .alert-link-as-btn[disabled]:focus,
+fieldset[disabled] .alert-warning .alert-link-as-btn:focus,
+.alert-warning .alert-link-as-btn.disabled:active,
+.alert-warning .alert-link-as-btn[disabled]:active,
+fieldset[disabled] .alert-warning .alert-link-as-btn:active,
+.alert-warning .alert-link-as-btn.disabled.active,
+.alert-warning .alert-link-as-btn[disabled].active,
+fieldset[disabled] .alert-warning .alert-link-as-btn.active {
+  background-color: #c67605;
+  border-color: transparent;
+}
+.alert-warning .alert-link-as-btn .badge {
+  color: #c67605;
+  background-color: #FFF;
+}
+.alert-warning .alert-link-as-btn:hover {
+  text-decoration: none;
+}
+.alert-warning small,
+.alert-warning .small {
+  color: #FFF;
+}
+.alert-danger {
+  background-color: #C9453E;
+  border-color: transparent;
+  color: #FFF;
+}
+.alert-danger hr {
+  border-top-color: rgba(0, 0, 0, 0);
+}
+.alert-danger .alert-link {
+  color: #e6e6e6;
+}
+.alert-danger .alert-link-as-btn {
+  display: inline-block;
+  font-weight: bold;
+  text-decoration: none;
+  color: #FFF;
+  background-color: #a13732;
+  border-color: transparent;
+  padding: 0px 10px 1px;
+  font-size: 14px;
+  line-height: 1.5;
+  border-radius: 9999px;
+}
+.alert .alert-danger .alert-link-as-btn {
+  background-color: #62221e;
+}
+.alert-danger .alert-link-as-btn:hover,
+.alert-danger .alert-link-as-btn:focus,
+.alert-danger .alert-link-as-btn:active,
+.alert-danger .alert-link-as-btn.active,
+.alert-danger .alert-link-as-btn.checked,
+.open .dropdown-toggle.alert-danger .alert-link-as-btn {
+  color: #FFF;
+  background-color: #822c28;
+  border-color: rgba(0, 0, 0, 0);
+}
+.alert .alert-danger .alert-link-as-btn:hover,
+.alert .alert-danger .alert-link-as-btn:focus,
+.alert .alert-danger .alert-link-as-btn:active,
+.alert .alert-danger .alert-link-as-btn.active,
+.alert .alert-danger .alert-link-as-btn.checked,
+.alert .open .dropdown-toggle.alert-danger .alert-link-as-btn {
+  background-color: #431715;
+}
+.alert-danger .alert-link-as-btn:active,
+.alert-danger .alert-link-as-btn.active,
+.open .dropdown-toggle.alert-danger .alert-link-as-btn {
+  background-image: none;
+}
+.alert-danger .alert-link-as-btn.disabled,
+.alert-danger .alert-link-as-btn[disabled],
+fieldset[disabled] .alert-danger .alert-link-as-btn,
+.alert-danger .alert-link-as-btn.disabled:hover,
+.alert-danger .alert-link-as-btn[disabled]:hover,
+fieldset[disabled] .alert-danger .alert-link-as-btn:hover,
+.alert-danger .alert-link-as-btn.disabled:focus,
+.alert-danger .alert-link-as-btn[disabled]:focus,
+fieldset[disabled] .alert-danger .alert-link-as-btn:focus,
+.alert-danger .alert-link-as-btn.disabled:active,
+.alert-danger .alert-link-as-btn[disabled]:active,
+fieldset[disabled] .alert-danger .alert-link-as-btn:active,
+.alert-danger .alert-link-as-btn.disabled.active,
+.alert-danger .alert-link-as-btn[disabled].active,
+fieldset[disabled] .alert-danger .alert-link-as-btn.active {
+  background-color: #a13732;
+  border-color: transparent;
+}
+.alert-danger .alert-link-as-btn .badge {
+  color: #a13732;
+  background-color: #FFF;
+}
+.alert-danger .alert-link-as-btn:hover {
+  text-decoration: none;
+}
+.alert-danger small,
+.alert-danger .small {
+  color: #FFF;
+}
+.alert-alt {
+  background-color: #E4E8EE;
+  border-color: transparent;
+  color: #5D6879;
+}
+.alert-alt hr {
+  border-top-color: rgba(0, 0, 0, 0);
+}
+.alert-alt .alert-link {
+  color: #474f5c;
+}
+.alert-alt .alert-link-as-btn {
+  display: inline-block;
+  font-weight: bold;
+  text-decoration: none;
+  color: #FFF;
+  background-color: #b6babe;
+  border-color: transparent;
+  padding: 0px 10px 1px;
+  font-size: 14px;
+  line-height: 1.5;
+  border-radius: 9999px;
+}
+.alert .alert-alt .alert-link-as-btn {
+  background-color: #8b9098;
+}
+.alert-alt .alert-link-as-btn:hover,
+.alert-alt .alert-link-as-btn:focus,
+.alert-alt .alert-link-as-btn:active,
+.alert-alt .alert-link-as-btn.active,
+.alert-alt .alert-link-as-btn.checked,
+.open .dropdown-toggle.alert-alt .alert-link-as-btn {
+  color: #FFF;
+  background-color: #a1a5ab;
+  border-color: rgba(0, 0, 0, 0);
+}
+.alert .alert-alt .alert-link-as-btn:hover,
+.alert .alert-alt .alert-link-as-btn:focus,
+.alert .alert-alt .alert-link-as-btn:active,
+.alert .alert-alt .alert-link-as-btn.active,
+.alert .alert-alt .alert-link-as-btn.checked,
+.alert .open .dropdown-toggle.alert-alt .alert-link-as-btn {
+  background-color: #767c85;
+}
+.alert-alt .alert-link-as-btn:active,
+.alert-alt .alert-link-as-btn.active,
+.open .dropdown-toggle.alert-alt .alert-link-as-btn {
+  background-image: none;
+}
+.alert-alt .alert-link-as-btn.disabled,
+.alert-alt .alert-link-as-btn[disabled],
+fieldset[disabled] .alert-alt .alert-link-as-btn,
+.alert-alt .alert-link-as-btn.disabled:hover,
+.alert-alt .alert-link-as-btn[disabled]:hover,
+fieldset[disabled] .alert-alt .alert-link-as-btn:hover,
+.alert-alt .alert-link-as-btn.disabled:focus,
+.alert-alt .alert-link-as-btn[disabled]:focus,
+fieldset[disabled] .alert-alt .alert-link-as-btn:focus,
+.alert-alt .alert-link-as-btn.disabled:active,
+.alert-alt .alert-link-as-btn[disabled]:active,
+fieldset[disabled] .alert-alt .alert-link-as-btn:active,
+.alert-alt .alert-link-as-btn.disabled.active,
+.alert-alt .alert-link-as-btn[disabled].active,
+fieldset[disabled] .alert-alt .alert-link-as-btn.active {
+  background-color: #b6babe;
+  border-color: transparent;
+}
+.alert-alt .alert-link-as-btn .badge {
+  color: #b6babe;
+  background-color: #FFF;
+}
+.alert-alt .alert-link-as-btn:hover {
+  text-decoration: none;
+}
+.alert-alt small,
+.alert-alt .small {
+  color: #5D6879;
+}
+.alert a,
+.alert .btn-inline-link {
+  color: white;
+  text-decoration: underline;
+}
+.alert .btn {
+  text-decoration: none;
+}

--- a/test/acceptance/coffee/LoginTests.coffee
+++ b/test/acceptance/coffee/LoginTests.coffee
@@ -1,0 +1,120 @@
+_ = require("lodash")
+async = require("async")
+{ JSDOM } = require("jsdom")
+{ expect } = require("chai")
+request = require("request")
+ReadOnlyApp = require("./helpers/ReadOnlyApp")
+MongoDb = require("./helpers/MongoDb")
+MockEmailServer = require("./helpers/MockEmailServer")
+
+describe "ReadOnly", ->
+	appUrl = (path) => new URL(path, "http://localhost:3038").toString()
+	parseHtml = (html) => new JSDOM(html).window.document
+
+	validateUserProjectPage = (user, html) =>
+		doc = parseHtml(html)
+		projectLinks = Array.from(doc.querySelectorAll('a[href^="/project/"]'))
+		projects = _.uniq(projectLinks.map((link) -> link.href.replace('/project/', '')))
+		expectedProjects = user.projects.map((project) => project._id.toString())
+		expect(projects).to.have.members(expectedProjects)
+
+	before "Ensure Mongo is running", (done) ->
+		MongoDb.ensureRunning(done)
+
+	before "Prepare dummy data", (done) ->
+		async.mapValuesSeries {
+			noProjects:
+				email: "no-projects@example.com"
+				password: "secret!"
+				numProjects: 0
+			oneProject:
+				email: "one-project@example.com"
+				password: "shhhhh!"
+				numProjects: 1
+			twoProjects:
+				email: "two-projects@example.com"
+				password: "password123"
+				numProjects: 2
+		}, (value, key, cb) =>
+			MongoDb.createDummyUser(value, cb)
+		, (err, users) =>
+			if err?
+				return done(err)
+			@users = users
+			done()
+
+	before "Ensure read-only is running", (done) ->
+		ReadOnlyApp.ensureRunning(done)
+
+	before "Ensure mock email server is running", (done) ->
+		MockEmailServer.ensureRunning(done)
+
+	describe "home page", ->
+		it "displays a login page", (done) ->
+			request.get appUrl("/"), (err, res) =>
+				if err?
+					return done(err)
+				expect(res.statusCode).to.equal(200)
+				doc = parseHtml(res.body)
+				loginForm = doc.querySelector('form[action="/login"]')
+				expect(loginForm).to.exist
+				done()
+
+	describe "password login", ->
+		it "logs the user in and shows the user's projects", (done) ->
+			user = @users.twoProjects
+			cookieJar = request.jar()
+			request.post {
+				url: appUrl("/login")
+				jar: cookieJar
+				form: {
+					email: user.email
+					password: user.password
+				}
+				followRedirect: (res) =>
+					return res.headers['location'] == '/project'
+				followAllRedirects: true
+			}, (err, res) =>
+				if err?
+					return done(err)
+				expect(res.statusCode).to.equal(200)
+				validateUserProjectPage(user, res.body)
+				done()
+
+	describe "one-time login", ->
+		it "sends an email with a one-time login link", (done) ->
+			user = @users.oneProject
+			cookieJar = request.jar()
+			async.auto {
+				email: (cb) ->
+					MockEmailServer.waitForEmail(cb)
+				requestResponse: (cb) ->
+					request.post {
+						url: appUrl("/one-time-login/request"),
+						jar: cookieJar
+						form: {
+							email: user.email
+						}
+						followAllRedirects: true
+					}, (err, res) =>
+						cb(err, res)
+				loginUrl: ['email', ({ email }, cb) ->
+					doc = parseHtml(email.html)
+					link = doc.querySelector('a[href*="one-time-login"]')
+					url = link.href
+					cb(null, url)
+				]
+				loginResponse: ['loginUrl', ({ loginUrl }, cb) ->
+					request.get {
+						url: loginUrl
+						jar: cookieJar
+					}, (err, res) =>
+						cb(err, res)
+				]
+			}, (err, { requestResponse, loginResponse }) =>
+					if err?
+						return done(err)
+					expect(requestResponse.statusCode).to.equal(200)
+					expect(loginResponse.statusCode).to.equal(200)
+					validateUserProjectPage(user, loginResponse.body)
+					done()

--- a/test/acceptance/coffee/helpers/MockEmailServer.coffee
+++ b/test/acceptance/coffee/helpers/MockEmailServer.coffee
@@ -1,0 +1,34 @@
+MailDev = require('maildev')
+logger = require('logger-sharelatex')
+
+module.exports = {
+	running: false
+	initing: false
+	startCallbacks: []
+	emailCallbacks: []
+	maildev: new MailDev()
+
+	ensureRunning: (callback) ->
+		if @running
+			return callback()
+		if @initing
+			@startCallbacks.push(callback)
+			return
+		@initing = true
+		@startCallbacks.push(callback)
+		@maildev.listen (err) =>
+			if !err
+				@running = true
+				@maildev.on('new', (email) => @handleNewEmail(email))
+				logger.info("Mock email server ready")
+			for callback in @startCallbacks
+				callback(err)
+
+	waitForEmail: (callback) ->
+		@emailCallbacks.push(callback)
+
+	handleNewEmail: (email) ->
+		for callback in @emailCallbacks
+			callback(null, email)
+		@emailCallbacks = []
+}

--- a/test/acceptance/coffee/helpers/MongoDb.coffee
+++ b/test/acceptance/coffee/helpers/MongoDb.coffee
@@ -1,0 +1,60 @@
+async = require("async")
+bcrypt = require("bcrypt")
+mongojs = require('mongojs')
+logger = require("logger-sharelatex")
+Settings = require("settings-sharelatex")
+
+module.exports =
+	running: false
+	initing: false
+	callbacks: []
+	db: mongojs(Settings.mongo.url, ['users', 'projects'])
+
+	ensureRunning: (callback) ->
+		if @running
+			return callback()
+		if @initing
+			@callbacks.push(callback)
+			return
+		@initing = true
+		@callbacks.push(callback)
+		# Force a connection by executing a command
+		@db.stats (err) =>
+			if !err
+				@running = true
+				logger.info("MongoDB ready")
+			for callback in @callbacks
+				callback(err)
+
+	createDummyUser: (params, callback) ->
+		{ email, password, numProjects } = params
+		async.auto {
+			hashedPassword: (cb) =>
+				bcrypt.hash(password, 10, cb)
+			user: ['hashedPassword', ({ hashedPassword }, cb) =>
+				@db.users.insert({
+					email: email
+					hashedPassword: hashedPassword
+				}, cb)
+			]
+			projects: ['user', ({ user }, cb) =>
+				if numProjects == 0
+					return cb(null, [])
+				projects = []
+				for i in [0...numProjects]
+					projects.push({
+						name: "Project #{i + 1}"
+						owner_ref: user._id
+						collaberator_refs: []
+						lastUpdated: new Date()
+						readOnly_refs: []
+					})
+				@db.projects.insert(projects, cb)
+			]
+		}, (err, { user, projects }) =>
+			if err?
+				return callback(err)
+			callback(null, Object.assign({
+				password: password
+				projects: projects
+			}, user))

--- a/test/acceptance/coffee/helpers/ReadOnlyApp.coffee
+++ b/test/acceptance/coffee/helpers/ReadOnlyApp.coffee
@@ -1,0 +1,24 @@
+app = require('../../../../app')
+require("logger-sharelatex").logger.level("info")
+logger = require("logger-sharelatex")
+Settings = require("settings-sharelatex")
+
+module.exports =
+	running: false
+	initing: false
+	callbacks: []
+
+	ensureRunning: (callback) ->
+		if @running
+			return callback()
+		if @initing
+			@callbacks.push(callback)
+			return
+		@initing = true
+		@callbacks.push(callback)
+		app.listen 3038, (err) =>
+			if !err
+				@running = true
+				logger.info("read-only running in dev mode")
+			for callback in @callbacks
+				callback(err)

--- a/test/mocha-init.js
+++ b/test/mocha-init.js
@@ -1,0 +1,3 @@
+const chai = require("chai")
+const sinonChai = require("sinon-chai")
+chai.use(sinonChai)

--- a/test/smoke/coffee/test.coffee
+++ b/test/smoke/coffee/test.coffee
@@ -15,12 +15,12 @@ buildUrl = (path) ->
 convertCookieFile = (callback) ->
 	fs = require("fs")
 	fs.readFile cookieFilePath, "utf8", (err, data) ->
-		return callback(err) if err
+		return callback(err) if err?
 		firstTrue = data.indexOf("TRUE")
 		secondTrue = data.indexOf("TRUE", firstTrue+4)
 		result = data.slice(0, secondTrue)+"FALSE"+data.slice(secondTrue+4)
 		fs.writeFile cookieFilePath, result, "utf8", (err) ->
-			return callback(err) if err
+			return callback(err) if err?
 			callback()
 
 describe "Log in and download project", ->

--- a/test/unit/coffee/AuthControllerTests.coffee
+++ b/test/unit/coffee/AuthControllerTests.coffee
@@ -1,0 +1,126 @@
+path = require('path')
+sinon = require('sinon')
+{ expect } = require('chai')
+SandboxedModule = require('sandboxed-module')
+Errors = require("../../../app/js/Errors")
+
+MODULE_PATH = path.join(__dirname, '../../../app/js/AuthController.js')
+
+describe 'AuthController', ->
+	beforeEach ->
+		@celebrate = {
+			isCelebrate: sinon.stub().returns(false)
+		}
+		@logger = {
+			info: sinon.stub()
+		}
+		@AuthHandler = {
+			login: sinon.stub()
+			oneTimeLogin: sinon.stub()
+			generateOneTimeLoginToken: sinon.stub()
+		}
+		@EmailHandler = {
+			sendOneTimeLoginEmail: sinon.stub().yields()
+		}
+		@AuthController = SandboxedModule.require(MODULE_PATH, {
+			requires:
+				'celebrate': @celebrate
+				'logger-sharelatex': @logger
+				'./AuthHandler': @AuthHandler
+				'./EmailHandler': @EmailHandler
+				'./Errors': Errors
+		})
+
+		@req = {
+			body: {}
+			session:
+				destroy: sinon.stub().yields()
+		}
+		@res = {
+			redirect: sinon.stub()
+			render: sinon.stub()
+		}
+		@next = sinon.stub()
+
+	describe "login", ->
+		beforeEach ->
+			@email = "user@example.com"
+			@password = "secret123"
+			@userId = "abc123"
+			@req.body = { email: @email, password: @password }
+
+		it "sets the session and redirects to the project page", (done) ->
+			@AuthHandler.login.withArgs(@email, @password).yields(null, @userId)
+			@res.redirect.callsFake (url) =>
+				expect(@req.session.user_id).to.equal(@userId)
+				expect(url).to.equal('/project')
+				done()
+
+			@AuthController.login(@req, @res, @next)
+
+	describe "handleLoginErrors", ->
+		it "rerenders the login screen on authentication failure", (done) ->
+			@res.render.callsFake (template, vars) =>
+				expect(template).to.equal("home")
+				expect(vars).to.deep.equal({ failedLogin: true })
+				done()
+
+			@AuthController.handleLoginErrors(new Errors.AuthenticationError(), @req, @res, @next)
+
+	describe "logout", ->
+		it "clears the session and redirects to the login page", (done) ->
+			@res.redirect.callsFake (url) =>
+				expect(url).to.equal("/")
+				expect(@req.session.destroy).to.have.been.called
+				done()
+
+			@AuthController.logout(@req, @res, @next)
+
+	describe "oneTimeLogin", ->
+		beforeEach ->
+			@email = "user@example.com"
+			@token = "secret123"
+			@userId = "abc123"
+			@req.query = { email: @email, token: @token }
+
+		it "sets the session and redirects to the project page", (done) ->
+			@AuthHandler.oneTimeLogin.withArgs(@email, @token).yields(null, @userId)
+			@res.redirect.callsFake (url) =>
+				expect(@req.session.user_id).to.equal(@userId)
+				expect(url).to.equal('/project')
+				done()
+
+			@AuthController.oneTimeLogin(@req, @res, @next)
+
+	describe "handleOneTimeLoginErrors", ->
+		it "rerenders the login screen on authentication failure", (done) ->
+			@res.render.callsFake (template, vars) =>
+				expect(template).to.equal("home")
+				expect(vars).to.deep.equal({ failedOneTimeLogin: true })
+				done()
+
+			@AuthController.handleOneTimeLoginErrors(new Errors.AuthenticationError(), @req, @res, @next)
+
+	describe "oneTimeLoginRequest", ->
+		it "sends an email with a one-time login token", (done) ->
+			email = "user@example.com"
+			token = "secret123"
+			@req.body = { email }
+			@AuthHandler.generateOneTimeLoginToken.withArgs(email).yields(null, token)
+			@res.render.callsFake () =>
+				expect(@EmailHandler.sendOneTimeLoginEmail).to.have.been.calledWith(email, token)
+				done()
+
+			@AuthController.oneTimeLoginRequest(@req, @res, @next)
+
+		it "rerenders the request form if the email is not registered", (done) ->
+			email = "not-a-user@example.com"
+			@req.body = { email }
+			@AuthHandler.generateOneTimeLoginToken.yields(new Errors.UserNotFoundError())
+			@res.render.callsFake (template, vars) =>
+				expect(template).to.equal("one-time-login-request-form")
+				expect(vars.email).to.equal(email)
+				expect(vars.error).to.exist
+				done()
+
+			@AuthController.oneTimeLoginRequest(@req, @res, @next)

--- a/test/unit/coffee/AuthHandlerTests.coffee
+++ b/test/unit/coffee/AuthHandlerTests.coffee
@@ -1,0 +1,171 @@
+_ = require("lodash")
+crypto = require("crypto")
+path = require('path')
+sinon = require('sinon')
+{ expect } = require('chai')
+SandboxedModule = require('sandboxed-module')
+{ ObjectId } = require('mongojs')
+Errors = require('../../../app/js/Errors')
+
+MODULE_PATH = path.join(__dirname, '../../../app/js/AuthHandler.js')
+
+describe 'AuthHandler', ->
+	beforeEach ->
+		@bcrypt = {
+			compare: sinon.stub()
+		}
+		@crypto = {
+			randomBytes: sinon.stub()
+			timingSafeEqual: crypto.timingSafeEqual
+		}
+		@logger = {
+			info: sinon.stub()
+		}
+		@db = {
+			users:
+				findOne: sinon.stub()
+			oneTimeLoginTokens:
+				findOne: sinon.stub()
+				insert: sinon.stub().yields()
+				update: sinon.stub().yields()
+		}
+		@AuthHandler = SandboxedModule.require(MODULE_PATH, {
+			requires:
+				'lodash': _
+				'bcrypt': @bcrypt
+				'crypto': @crypto
+				'logger-sharelatex': @logger
+				'./MongoHandler': { db: @db }
+				'./Errors': Errors
+		})
+
+	describe "login", ->
+		beforeEach ->
+			@email = 'user@example.com'
+			@password = 'secret'
+			@userId = 'aaaaaaaaaaaaaaaaaaaaaaaa'
+			@user = {
+				_id: ObjectId(@userId)
+				hashedPassword: 'hashed-secret'
+			}
+			@db.users.findOne.yields(null, null)
+			@db.users.findOne.withArgs({ @email }).yields(null, @user)
+			@bcrypt.compare.yields(null, false)
+			@bcrypt.compare.withArgs(@password, @user.hashedPassword).yields(null, true)
+
+		it "checks the password and returns the user id", (done) ->
+			@AuthHandler.login @email, @password, (err, userId) =>
+				if err?
+					return done(err)
+				expect(userId).to.equal(@userId)
+				done()
+
+		it "is case-insensitive relative to the email", (done) ->
+			@AuthHandler.login "User@Example.Com", @password, (err, userId) =>
+				if err?
+					return done(err)
+				expect(userId).to.equal(@userId)
+				done()
+
+		it "throws an AuthenticationError if the user doesn't exist", (done) ->
+			@AuthHandler.login "incorrect@email.com", @password, (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+		it "throws an AuthenticationError if the password is wrong", (done) ->
+			@AuthHandler.login @email, "not-a-pass", (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+		it "throws an AuthenticationError if the user doesn't have a password", (done) ->
+			delete @user.hashedPassword
+			@AuthHandler.login @email, @password, (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+	describe "oneTimeLogin", ->
+		beforeEach ->
+			@email = 'user@example.com'
+			@token = 'secret123'
+			@userId = new ObjectId()
+			@tokenId = new ObjectId()
+			@user = { _id: @userId }
+			@db.oneTimeLoginTokens.findOne.yields(null, null)
+			@db.oneTimeLoginTokens.findOne
+				.withArgs(sinon.match({ email: @email }))
+				.yields(null, { _id: @tokenId, token: @token })
+			@db.users.findOne.yields(null, null)
+			@db.users.findOne.withArgs({ email: @email }).yields(null, @user)
+
+		it "picks an unused token, uses it and returns the user id", (done) ->
+			@AuthHandler.oneTimeLogin @email, @token, (err, userId) =>
+				if err?
+					return done(err)
+				expect(@db.oneTimeLoginTokens.findOne).to.have.been.calledWith(sinon.match({
+					usedAt: { $exists: false }
+				}))
+				expect(@db.oneTimeLoginTokens.update).to.have.been.calledWith(
+					{ _id: @tokenId }
+					{
+						$set:
+							usedAt: sinon.match.date
+					}
+				)
+				expect(userId).to.equal(@userId.toString())
+				done()
+
+		it "is case-insensitive relative to the email", (done) ->
+			@AuthHandler.oneTimeLogin "User@Example.Com", @token, (err, userId) =>
+				if err?
+					return done(err)
+				expect(userId).to.equal(@userId.toString())
+				done()
+
+		it "throws an AuthenticationError when the token is invalid", (done) ->
+			@AuthHandler.oneTimeLogin @email, "secret456", (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+		it "throws an AuthenticationError when the token is empty", (done) ->
+			@AuthHandler.oneTimeLogin @email, "", (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+		it "throws an AuthenticationError when the token is the wrong length", (done) ->
+			@AuthHandler.oneTimeLogin @email, "bad-token-too-long", (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+		it "throws an AuthenticationError when the email has no token", (done) ->
+			@AuthHandler.oneTimeLogin 'unknown@email.com', @token, (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+		it "throws an AuthenticationError when the user does not exist", (done) ->
+			@db.users.findOne.withArgs({ email: @email }).yields(null, null)
+			@AuthHandler.oneTimeLogin @email, "bad-token", (err) =>
+				expect(err).to.be.instanceof(Errors.AuthenticationError)
+				done()
+
+	describe "generateOneTimeLoginToken", ->
+		it "generates a token and inserts it in the database", (done) ->
+			email = 'user@example.com'
+			@db.users.findOne.yields(null, { email })
+			@db.oneTimeLoginTokens.insert
+			@crypto.randomBytes.returns(Buffer.from([0xde, 0xad, 0xbe, 0xef]))
+
+			@AuthHandler.generateOneTimeLoginToken email, (err, token) =>
+				expect(@db.oneTimeLoginTokens.insert).to.have.been.calledWith({
+					email: email
+					token: "deadbeef"
+					createdAt: sinon.match.date
+					expiresAt: sinon.match.date
+				})
+				done()
+
+		it "throws a UserNotFoundError when the user does not exist", (done) ->
+			@db.users.findOne.yields(null, null)
+
+			@AuthHandler.generateOneTimeLoginToken 'not-a-user@example.com', (err, token) =>
+				expect(err).to.be.instanceof(Errors.UserNotFoundError)
+				done()

--- a/test/unit/coffee/EmailHandlerTests.coffee
+++ b/test/unit/coffee/EmailHandlerTests.coffee
@@ -1,0 +1,44 @@
+path = require('path')
+sinon = require('sinon')
+{ expect } = require('chai')
+SandboxedModule = require('sandboxed-module')
+{ ObjectId } = require('mongojs')
+
+MODULE_PATH = path.join(__dirname, '../../../app/js/EmailHandler.js')
+
+describe 'EmailHandler', ->
+	beforeEach ->
+		@Settings = {
+			email:
+				fromAddress: "Overleaf team <welcome@overleaf.com>"
+				replyToAddress: "welcome@overleaf.com"
+		}
+		@logger = {
+			info: sinon.stub()
+		}
+		@EmailSender = {
+			sendMail: sinon.stub().yields()
+		}
+		@EmailHandler = SandboxedModule.require(MODULE_PATH, {
+			requires:
+				'settings-sharelatex': @Settings
+				'logger-sharelatex': @logger
+				'./EmailSender': @EmailSender
+		})
+
+	describe "sendOneTimeLoginEmail", ->
+		it "builds and sends an email", (done) ->
+			email = "user@example.com"
+			token = "secret123"
+			@EmailHandler.sendOneTimeLoginEmail email, token, (err) =>
+				if err?
+					return done(err)
+				expect(@EmailSender.sendMail).to.have.been.calledWith({
+					to: email
+					from: @Settings.email.fromAddress
+					replyTo: @Settings.email.replyToAddress
+					subject: "Overleaf Read Only Access"
+					text: sinon.match(/secret123/)
+					html: sinon.match(/secret123/)
+				})
+				done()


### PR DESCRIPTION
### Description

* The user makes a one-time login request by providing their email
* An email containing a link to a one-time login endpoint is sent to the
  user
* The endpoint logs the user in and discards the token so that the link
  cannot be used repeatedly

#### Screenshots

![one-time-login-1](https://user-images.githubusercontent.com/5454374/60398051-ef264700-9b21-11e9-917b-0ee6721c43b3.png)
![one-time-login-2](https://user-images.githubusercontent.com/5454374/60398052-ef264700-9b21-11e9-9e65-61fb68f04f93.png)
![one-time-login-3](https://user-images.githubusercontent.com/5454374/60398053-efbedd80-9b21-11e9-88b7-d643799aa651.png)
![one-time-login-4](https://user-images.githubusercontent.com/5454374/60398054-efbedd80-9b21-11e9-8546-013227a16009.png)

#### Related Issues / PRs

* Issue: https://github.com/overleaf/google-ops/issues/334
* dev-environment PR: https://github.com/overleaf/dev-environment/pull/232

### Review

There is quite a bit of messaging involved. I'll need someone to review the copy.

I added a logout endpoint to ease testing, but I didn't include it in the UI yet. This is probably something we will want to add in another PR.

#### Potential Impact

This mechanism will be used by users who don't have a password associated with their Overleaf accounts. This includes people who authenticate via Google, Twitter, etc.

#### Manual Testing Performed

- [x] Follow the one-time login flow
- [x] Try to use a bad token
- [x] Login with password
- [x] Try to login with a bad password

#### Accessibility

Every form field is easily accessible via tabbing.

### Deployment

The read-only site is not deployed yet.