### PR TITLE
Support MONGO_URL env variable

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -2,6 +2,7 @@ http = require('http')
 http.globalAgent.maxSockets = 300
 
 MONGO_HOST = process.env['MONGO_HOST'] or "localhost"
+MONGO_URL = process.env['MONGO_URL'] or "mongodb://#{MONGO_HOST}/read_only"
 PROJECT_ARCHIVER_HOST = process.env['PROJECT_ARCHIVER_HOST'] or "localhost"
 
 module.exports =
@@ -15,7 +16,7 @@ module.exports =
 			url: "http://#{PROJECT_ARCHIVER_HOST}:3020"
 
 	mongo:
-		url: "mongodb://#{MONGO_HOST}/read_only"
+		url: MONGO_URL
 
 	cookieName: "sharelatex_read_only.sid"
 	cookieSessionLength: 5 * 24 * 60 * 60 * 1000


### PR DESCRIPTION
### Description

Specifying the complete Mongo URL will allow us to leverage Mongo
Atlas's [service discovery feature](https://docs.mongodb.com/manual/reference/connection-string/#connections-dns-seedlist)

#### Related Issues / PRs

* Issue: https://github.com/overleaf/google-ops/issues/334

### Review

I opted to support both `MONGO_HOST` and `MONGO_URL`. I could also only support `MONGO_URL`, but that would require a change in dev-environment.

#### Manual Testing Performed

- [x] Deployed in staging and could connect to Mongo Atlas
