### PR TITLE
Fixes for GKE

### DIFF
--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -61,4 +61,4 @@ module.exports = Router =
 			logger.log "hit status"
 			res.send('read-only is alive')
 
-		app.get '/health_check', SmokeTest.run(__dirname + "/test/smoke/js/test.js", 30000)
+		app.get '/health_check', SmokeTest.run(__dirname + "../../../test/smoke/js/test.js", 30000)

--- a/app/coffee/SessionMiddleware.coffee
+++ b/app/coffee/SessionMiddleware.coffee
@@ -17,7 +17,6 @@ middleware = session({
 	proxy: Settings.behindProxy
 	cookie:
 		domain: Settings.cookieDomain
-		maxAge: Settings.cookieSessionLength
 		secure: Settings.secureCookie
 	store: sessionStore
 	key: Settings.cookieName

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -1,4 +1,6 @@
 http = require('http')
+yn = require('yn')
+
 http.globalAgent.maxSockets = 300
 
 MONGO_HOST = process.env['MONGO_HOST'] or "localhost"
@@ -33,16 +35,18 @@ module.exports =
 	mongo:
 		url: MONGO_URL
 
-	cookieName: "sharelatex_read_only.sid"
-	cookieSessionLength: 5 * 24 * 60 * 60 * 1000
-	secureCookie: false
-	behindProxy: false
+	cookieName: "overleaf_read_only.sid"
+	cookieDomain: process.env['COOKIE_DOMAIN']
+	secureCookie: yn(process.env['SECURE_COOKIE'], { default: false })
+	behindProxy: yn(process.env['BEHIND_PROXY'], { default: false })
+
 	security:
-		sessionSecret: "banana"
+		sessionSecret: process.env['SESSION_SECRET'] or "not-so-secret"
 
 	email:
 		fromAddress: "Overleaf <welcome@overleaf.com>"
 		replyToAddress: "welcome@overleaf.com"
 		transport: process.env['EMAIL_TRANSPORT']
 		parameters: emailTransportParams
+
 	siteUrl: process.env['PUBLIC_URL'] or "http://localhost:#{HOST_LISTEN_PORT}"

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -23,25 +23,14 @@ emailTransportParams = switch process.env['EMAIL_TRANSPORT']
 	else {}
 
 module.exports =
-	internal:
-		read_only:
-			host: process.env['LISTEN_ADDRESS'] or "localhost"
-			port: HOST_LISTEN_PORT
+	behindProxy: yn(process.env['BEHIND_PROXY'], { default: false })
+	cookieDomain: process.env['COOKIE_DOMAIN']
+	cookieName: "overleaf_read_only.sid"
+	secureCookie: yn(process.env['SECURE_COOKIE'], { default: false })
 
 	apis:
 		project_archiver:
 			url: "http://#{PROJECT_ARCHIVER_HOST}:3020"
-
-	mongo:
-		url: MONGO_URL
-
-	cookieName: "overleaf_read_only.sid"
-	cookieDomain: process.env['COOKIE_DOMAIN']
-	secureCookie: yn(process.env['SECURE_COOKIE'], { default: false })
-	behindProxy: yn(process.env['BEHIND_PROXY'], { default: false })
-
-	security:
-		sessionSecret: process.env['SESSION_SECRET'] or "not-so-secret"
 
 	email:
 		fromAddress: "Overleaf <welcome@overleaf.com>"
@@ -49,4 +38,20 @@ module.exports =
 		transport: process.env['EMAIL_TRANSPORT']
 		parameters: emailTransportParams
 
+	internal:
+		read_only:
+			host: process.env['LISTEN_ADDRESS'] or "localhost"
+			port: HOST_LISTEN_PORT
+
+	mongo:
+		url: MONGO_URL
+
+	security:
+		sessionSecret: process.env['SESSION_SECRET'] or "not-so-secret"
+
 	siteUrl: process.env['PUBLIC_URL'] or "http://localhost:#{HOST_LISTEN_PORT}"
+
+	smokeTest:
+		email: process.env['SMOKE_TEST_EMAIL']
+		password: process.env['SMOKE_TEST_PASSWORD']
+		projectId: process.env['SMOKE_TEST_PROJECT_ID']

--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,6 +6848,11 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
+    },
+    "yn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "pug": "^2.0.4",
     "request": "^2.88.0",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
-    "smoke-test-sharelatex": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#master"
+    "smoke-test-sharelatex": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#master",
+    "yn": "^3.1.0"
   },
   "devDependencies": {
     "bunyan": "~0.22.3",


### PR DESCRIPTION
### Description

These are small fixes I needed to make in order to make read-only run correctly in GKE.

* There was a bug in the smoke test path that broke the health check
* Smoke tests were not configured
* Cookie settings were not configurable

While I was meddling with cookie configuration, I removed the max-age parameter, which makes the session cookie non-persistent, i.e. it should be discarded when users close their browser windows.

#### Related PRs and issues

* Issue: https://github.com/overleaf/google-ops/issues/334
* Google ops PR: https://github.com/overleaf/google-ops/pull/368

### Review

#### Manual Testing Performed

- [ ] Log in to https://read-only.stag-overleaf.com/ with the smoke test user. It's the only one in the database yet.

### Deployment

This is deployed in staging. We don't deploy in production just yet.
