### PR TITLE
Rate limit login endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ const Settings = require('settings-sharelatex')
 const logger = require('logger-sharelatex')
 const express = require('express')
 const Metrics = require('metrics-sharelatex')
-const path = require('path')
+const Path = require('path')
 
 const EmailSender = require('./app/js/EmailSender')
 const MongoHandler = require('./app/js/MongoHandler')
@@ -14,8 +14,9 @@ logger.initialize('read-only')
 EmailSender.initialize()
 
 const app = express()
-app.set('views', path.join(__dirname, 'app/views'))
+app.set('views', Path.join(__dirname, 'app/views'))
 app.set('view engine', 'pug')
+app.set('trust proxy', Settings.behindProxy)
 Router.initialize(app)
 
 const { port } = Settings.internal.read_only

--- a/app.js
+++ b/app.js
@@ -1,21 +1,9 @@
-/* eslint-disable
-    no-path-concat,
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const async = require('async')
 const Settings = require('settings-sharelatex')
 const logger = require('logger-sharelatex')
 const express = require('express')
 const Metrics = require('metrics-sharelatex')
-const Path = require('path')
+const path = require('path')
 
 const EmailSender = require('./app/js/EmailSender')
 const MongoHandler = require('./app/js/MongoHandler')
@@ -26,7 +14,7 @@ logger.initialize('read-only')
 EmailSender.initialize()
 
 const app = express()
-app.set('views', __dirname + '/app/views')
+app.set('views', path.join(__dirname, 'app/views'))
 app.set('view engine', 'pug')
 Router.initialize(app)
 
@@ -37,18 +25,18 @@ if (!module.parent) {
   async.series(
     {
       initDb(cb) {
-        return MongoHandler.initialize(cb)
+        MongoHandler.initialize(cb)
       },
       startHttpServer(cb) {
         logger.info('Starting HTTP server')
-        return app.listen(port, host, cb)
+        app.listen(port, host, cb)
       }
     },
     function(err) {
       if (err != null) {
         throw err
       }
-      return logger.info(`HTTP server ready and listening on ${host}:${port}`)
+      logger.info(`HTTP server ready and listening on ${host}:${port}`)
     }
   )
 }

--- a/app/js/AuthController.js
+++ b/app/js/AuthController.js
@@ -1,15 +1,3 @@
-/* eslint-disable
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-let AuthController
 const logger = require('logger-sharelatex')
 const { isCelebrate } = require('celebrate')
 
@@ -17,80 +5,80 @@ const AuthHandler = require('./AuthHandler')
 const EmailHandler = require('./EmailHandler')
 const Errors = require('./Errors')
 
-module.exports = AuthController = {
+module.exports = {
   login(req, res, next) {
     const { email, password } = req.body
     logger.info({ email }, 'received password login request')
-    return AuthHandler.login(email, password, function(err, userId) {
+    AuthHandler.login(email, password, function(err, userId) {
       if (err != null) {
         return next(err)
       }
       logger.info({ email, userId }, 'successful login')
       req.session.user_id = userId
-      return res.redirect('/project')
+      res.redirect('/project')
     })
   },
 
   handleLoginErrors(err, req, res, next) {
     if (err instanceof Errors.AuthenticationError || isCelebrate(err)) {
-      return res.render('home', { failedLogin: true })
+      res.render('home', { failedLogin: true })
     } else {
-      return next(err)
+      next(err)
     }
   },
 
   logout(req, res, next) {
-    return req.session.destroy(function(err) {
+    req.session.destroy(function(err) {
       if (err != null) {
         return next(err)
       }
-      return res.redirect('/')
+      res.redirect('/')
     })
   },
 
   oneTimeLogin(req, res, next) {
     const { email, token } = req.query
     logger.info({ email }, 'received one-time login request')
-    return AuthHandler.oneTimeLogin(email, token, function(err, userId) {
+    AuthHandler.oneTimeLogin(email, token, function(err, userId) {
       if (err != null) {
         return next(err)
       }
       logger.info({ email, userId }, 'successful one-time login')
       req.session.user_id = userId
-      return res.redirect('/project')
+      res.redirect('/project')
     })
   },
 
   handleOneTimeLoginErrors(err, req, res, next) {
     if (err instanceof Errors.AuthenticationError || isCelebrate(err)) {
-      return res.render('home', { failedOneTimeLogin: true })
+      res.render('home', { failedOneTimeLogin: true })
     } else {
-      return next(err)
+      next(err)
     }
   },
 
   oneTimeLoginRequestForm(req, res, next) {
-    return res.render('one-time-login-request-form')
+    res.render('one-time-login-request-form')
   },
 
   oneTimeLoginRequest(req, res, next) {
     const { email } = req.body
-    return AuthHandler.generateOneTimeLoginToken(email, function(err, token) {
+    AuthHandler.generateOneTimeLoginToken(email, function(err, token) {
       if (err != null) {
         if (err instanceof Errors.UserNotFoundError) {
-          return res.render('one-time-login-request-form', {
+          res.render('one-time-login-request-form', {
             error: 'This email address is not registered in Overleaf',
             email
           })
         } else {
-          return next(err)
+          next(err)
         }
       } else {
-        return EmailHandler.sendOneTimeLoginEmail(email, token, function(err) {
+        EmailHandler.sendOneTimeLoginEmail(email, token, function(err) {
           if (err != null) {
             return next(err)
           }
-          return res.render('one-time-login-email-sent')
+          res.render('one-time-login-email-sent')
         })
       }
     })
@@ -98,12 +86,12 @@ module.exports = AuthController = {
 
   handleOneTimeLoginRequestErrors(err, req, res, next) {
     if (err instanceof Errors.UserNotFoundError || isCelebrate(err)) {
-      return res.render('one-time-login-request-form', {
+      res.render('one-time-login-request-form', {
         error: 'This email address is not registered in Overleaf',
         email: req.body.email
       })
     } else {
-      return next(err)
+      next(err)
     }
   }
 }

--- a/app/js/AuthController.js
+++ b/app/js/AuthController.js
@@ -21,7 +21,7 @@ module.exports = {
 
   handleLoginErrors(err, req, res, next) {
     if (err instanceof Errors.AuthenticationError || isCelebrate(err)) {
-      res.render('home', { failedLogin: true })
+      res.status(400).render('home', { failedLogin: true })
     } else {
       next(err)
     }
@@ -51,7 +51,7 @@ module.exports = {
 
   handleOneTimeLoginErrors(err, req, res, next) {
     if (err instanceof Errors.AuthenticationError || isCelebrate(err)) {
-      res.render('home', { failedOneTimeLogin: true })
+      res.status(400).render('home', { failedOneTimeLogin: true })
     } else {
       next(err)
     }
@@ -66,7 +66,7 @@ module.exports = {
     AuthHandler.generateOneTimeLoginToken(email, function(err, token) {
       if (err != null) {
         if (err instanceof Errors.UserNotFoundError) {
-          res.render('one-time-login-request-form', {
+          res.status(400).render('one-time-login-request-form', {
             error: 'This email address is not registered in Overleaf',
             email
           })
@@ -86,7 +86,7 @@ module.exports = {
 
   handleOneTimeLoginRequestErrors(err, req, res, next) {
     if (err instanceof Errors.UserNotFoundError || isCelebrate(err)) {
-      res.render('one-time-login-request-form', {
+      res.status(400).render('one-time-login-request-form', {
         error: 'This email address is not registered in Overleaf',
         email: req.body.email
       })

--- a/app/js/RateLimitMiddleware.js
+++ b/app/js/RateLimitMiddleware.js
@@ -1,0 +1,39 @@
+const rateLimit = require('express-rate-limit')
+const logger = require('logger-sharelatex')
+
+const LOGIN_RATE_LIMIT_WINDOW_MS = 60000
+const LOGIN_RATE_LIMIT_MAX_REQUESTS = 10
+
+module.exports = {
+  loginRateLimiter,
+  tokenRequestRateLimiter
+}
+
+function loginRateLimiter(endpoint) {
+  return rateLimit({
+    max: LOGIN_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: LOGIN_RATE_LIMIT_WINDOW_MS,
+    skipSuccessfulRequests: true,
+    headers: false,
+    handler: (req, res) => {
+      res.status(429).render('too-many-login-attempts')
+    },
+    onLimitReached: _handleRateLimitReached
+  })
+}
+
+function tokenRequestRateLimiter(endpoint) {
+  return rateLimit({
+    max: LOGIN_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: LOGIN_RATE_LIMIT_WINDOW_MS,
+    headers: false,
+    handler: (req, res) => {
+      res.status(429).render('too-many-token-requests')
+    },
+    onLimitReached: _handleRateLimitReached
+  })
+}
+
+function _handleRateLimitReached(req) {
+  logger.warn({ req }, 'rate limit reached')
+}

--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -1,15 +1,4 @@
-/* eslint-disable
-    no-path-concat,
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-let Router
+const path = require('path')
 const BodyParser = require('body-parser')
 const { celebrate, Joi } = require('celebrate')
 const express = require('express')
@@ -20,75 +9,77 @@ const AuthController = require('./AuthController')
 const HttpController = require('./HttpController')
 const SessionMiddleware = require('./SessionMiddleware')
 
-module.exports = Router = {
-  initialize(app) {
-    app.use(express.static('public'))
-    app.use(SessionMiddleware.middleware)
-    app.use(BodyParser.urlencoded({ extended: false }))
+module.exports = {
+  initialize
+}
 
-    app.get('/', HttpController.home)
+function initialize(app) {
+  app.use(express.static('public'))
+  app.use(SessionMiddleware.middleware)
+  app.use(BodyParser.urlencoded({ extended: false }))
 
-    app.post(
-      '/login',
-      celebrate({
-        body: Joi.object({
-          email: Joi.string()
-            .trim()
-            .email()
-            .required(),
-          password: Joi.string()
-            .trim()
-            .required()
-        })
-      }),
-      AuthController.login,
-      AuthController.handleLoginErrors
-    )
+  app.get('/', HttpController.home)
 
-    app.get('/logout', AuthController.logout)
-    app.get('/one-time-login/request', AuthController.oneTimeLoginRequestForm)
+  app.post(
+    '/login',
+    celebrate({
+      body: Joi.object({
+        email: Joi.string()
+          .trim()
+          .email()
+          .required(),
+        password: Joi.string()
+          .trim()
+          .required()
+      })
+    }),
+    AuthController.login,
+    AuthController.handleLoginErrors
+  )
 
-    app.post(
-      '/one-time-login/request',
-      celebrate({
-        body: Joi.object({
-          email: Joi.string()
-            .trim()
-            .email()
-            .required()
-        })
-      }),
-      AuthController.oneTimeLoginRequest,
-      AuthController.handleOneTimeLoginRequestErrors
-    )
+  app.get('/logout', AuthController.logout)
+  app.get('/one-time-login/request', AuthController.oneTimeLoginRequestForm)
 
-    app.get(
-      '/one-time-login',
-      celebrate({
-        query: Joi.object({
-          email: Joi.string()
-            .email()
-            .required(),
-          token: Joi.string()
-            .regex(/^[0-9a-f]{64}$/, 'token')
-            .required()
-        })
-      }),
-      AuthController.oneTimeLogin,
-      AuthController.handleOneTimeLoginErrors
-    )
+  app.post(
+    '/one-time-login/request',
+    celebrate({
+      body: Joi.object({
+        email: Joi.string()
+          .trim()
+          .email()
+          .required()
+      })
+    }),
+    AuthController.oneTimeLoginRequest,
+    AuthController.handleOneTimeLoginRequestErrors
+  )
 
-    app.get('/project', HttpController.projects)
-    app.get('/project/:project_id', HttpController.getProject)
+  app.get(
+    '/one-time-login',
+    celebrate({
+      query: Joi.object({
+        email: Joi.string()
+          .email()
+          .required(),
+        token: Joi.string()
+          .regex(/^[0-9a-f]{64}$/, 'token')
+          .required()
+      })
+    }),
+    AuthController.oneTimeLogin,
+    AuthController.handleOneTimeLoginErrors
+  )
 
-    app.get('/status', function(req, res) {
-      logger.log('hit status')
-      return res.send('read-only is alive')
-    })
+  app.get('/project', HttpController.projects)
+  app.get('/project/:project_id', HttpController.getProject)
 
-    return app.get(
-      '/health_check',
-      SmokeTest.run(__dirname + '../../../test/smoke/js/test.js', 30000)
-    )
-  }
+  app.get('/status', function(req, res) {
+    logger.log('hit status')
+    res.send('read-only is alive')
+  })
+
+  app.get(
+    '/health_check',
+    SmokeTest.run(path.join(__dirname, '../../../test/smoke/js/test.js'), 30000)
+  )
 }

--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -8,6 +8,7 @@ const SmokeTest = require('smoke-test-sharelatex')
 const AuthController = require('./AuthController')
 const HttpController = require('./HttpController')
 const SessionMiddleware = require('./SessionMiddleware')
+const RateLimitMiddleware = require('./RateLimitMiddleware')
 
 module.exports = {
   initialize
@@ -33,6 +34,7 @@ function initialize(app) {
           .required()
       })
     }),
+    RateLimitMiddleware.loginRateLimiter(),
     AuthController.login,
     AuthController.handleLoginErrors
   )
@@ -50,6 +52,7 @@ function initialize(app) {
           .required()
       })
     }),
+    RateLimitMiddleware.tokenRequestRateLimiter(),
     AuthController.oneTimeLoginRequest,
     AuthController.handleOneTimeLoginRequestErrors
   )
@@ -66,6 +69,7 @@ function initialize(app) {
           .required()
       })
     }),
+    RateLimitMiddleware.loginRateLimiter(),
     AuthController.oneTimeLogin,
     AuthController.handleOneTimeLoginErrors
   )
@@ -80,6 +84,6 @@ function initialize(app) {
 
   app.get(
     '/health_check',
-    SmokeTest.run(path.join(__dirname, '../../../test/smoke/js/test.js'), 30000)
+    SmokeTest.run(path.join(__dirname, '../../test/smoke/js/test.js'), 30000)
   )
 }

--- a/app/views/too-many-login-attempts.pug
+++ b/app/views/too-many-login-attempts.pug
@@ -1,0 +1,13 @@
+extends ./layout
+
+block content
+	.container
+		.row-spaced
+		.row
+			.col-md-6.col-md-offset-3
+				.card
+					.alert.alert-danger Too many requests
+					p
+						| We have detected an unusual number of failed login
+						| attempts originating from your IP address. Please try
+						| again in a few minutes.

--- a/app/views/too-many-token-requests.pug
+++ b/app/views/too-many-token-requests.pug
@@ -1,0 +1,13 @@
+extends ./layout
+
+block content
+	.container
+		.row-spaced
+		.row
+			.col-md-6.col-md-offset-3
+				.card
+					.alert.alert-danger Too many requests
+					p
+						| We have detected an unusual number of access requests
+						| originating from your IP address. Please try again in
+						| a few minutes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,6 +2616,11 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.0.0.tgz",
+      "integrity": "sha512-dhT57wqxfqmkOi4HM7NuT4Gd7gbUgSK2ocG27Y6lwm8lbOAw9XQfeANawGq8wLDtlGPO1ZgDj0HmKsykTxfFAg=="
+    },
     "express-session": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "coffeescript": "^1.12.7",
     "connect-mongo": "^3.0.0",
     "express": "^4.17.1",
+    "express-rate-limit": "^5.0.0",
     "express-session": "^1.12.1",
     "lodash": "^4.17.11",
     "logger-sharelatex": "^1.7.0",

--- a/test/unit/js/AuthControllerTests.js
+++ b/test/unit/js/AuthControllerTests.js
@@ -1,14 +1,3 @@
-/* eslint-disable
-    no-return-assign,
-    no-undef,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const path = require('path')
 const sinon = require('sinon')
 const { expect } = require('chai')
@@ -53,7 +42,7 @@ describe('AuthController', function() {
       redirect: sinon.stub(),
       render: sinon.stub()
     }
-    return (this.next = sinon.stub())
+    this.next = sinon.stub()
   })
 
   describe('login', function() {
@@ -61,20 +50,20 @@ describe('AuthController', function() {
       this.email = 'user@example.com'
       this.password = 'secret123'
       this.userId = 'abc123'
-      return (this.req.body = { email: this.email, password: this.password })
+      this.req.body = { email: this.email, password: this.password }
     })
 
-    return it('sets the session and redirects to the project page', function(done) {
+    it('sets the session and redirects to the project page', function(done) {
       this.AuthHandler.login
         .withArgs(this.email, this.password)
         .yields(null, this.userId)
       this.res.redirect.callsFake(url => {
         expect(this.req.session.user_id).to.equal(this.userId)
         expect(url).to.equal('/project')
-        return done()
+        done()
       })
 
-      return this.AuthController.login(this.req, this.res, this.next)
+      this.AuthController.login(this.req, this.res, this.next)
     })
   })
 
@@ -83,10 +72,10 @@ describe('AuthController', function() {
       this.res.render.callsFake((template, vars) => {
         expect(template).to.equal('home')
         expect(vars).to.deep.equal({ failedLogin: true })
-        return done()
+        done()
       })
 
-      return this.AuthController.handleLoginErrors(
+      this.AuthController.handleLoginErrors(
         new Errors.AuthenticationError(),
         this.req,
         this.res,
@@ -99,10 +88,10 @@ describe('AuthController', function() {
       this.res.redirect.callsFake(url => {
         expect(url).to.equal('/')
         expect(this.req.session.destroy).to.have.been.called
-        return done()
+        done()
       })
 
-      return this.AuthController.logout(this.req, this.res, this.next)
+      this.AuthController.logout(this.req, this.res, this.next)
     }))
 
   describe('oneTimeLogin', function() {
@@ -110,20 +99,20 @@ describe('AuthController', function() {
       this.email = 'user@example.com'
       this.token = 'secret123'
       this.userId = 'abc123'
-      return (this.req.query = { email: this.email, token: this.token })
+      this.req.query = { email: this.email, token: this.token }
     })
 
-    return it('sets the session and redirects to the project page', function(done) {
+    it('sets the session and redirects to the project page', function(done) {
       this.AuthHandler.oneTimeLogin
         .withArgs(this.email, this.token)
         .yields(null, this.userId)
       this.res.redirect.callsFake(url => {
         expect(this.req.session.user_id).to.equal(this.userId)
         expect(url).to.equal('/project')
-        return done()
+        done()
       })
 
-      return this.AuthController.oneTimeLogin(this.req, this.res, this.next)
+      this.AuthController.oneTimeLogin(this.req, this.res, this.next)
     })
   })
 
@@ -132,10 +121,10 @@ describe('AuthController', function() {
       this.res.render.callsFake((template, vars) => {
         expect(template).to.equal('home')
         expect(vars).to.deep.equal({ failedOneTimeLogin: true })
-        return done()
+        done()
       })
 
-      return this.AuthController.handleOneTimeLoginErrors(
+      this.AuthController.handleOneTimeLoginErrors(
         new Errors.AuthenticationError(),
         this.req,
         this.res,
@@ -143,7 +132,7 @@ describe('AuthController', function() {
       )
     }))
 
-  return describe('oneTimeLoginRequest', function() {
+  describe('oneTimeLoginRequest', function() {
     it('sends an email with a one-time login token', function(done) {
       const email = 'user@example.com'
       const token = 'secret123'
@@ -156,17 +145,13 @@ describe('AuthController', function() {
           email,
           token
         )
-        return done()
+        done()
       })
 
-      return this.AuthController.oneTimeLoginRequest(
-        this.req,
-        this.res,
-        this.next
-      )
+      this.AuthController.oneTimeLoginRequest(this.req, this.res, this.next)
     })
 
-    return it('rerenders the request form if the email is not registered', function(done) {
+    it('rerenders the request form if the email is not registered', function(done) {
       const email = 'not-a-user@example.com'
       this.req.body = { email }
       this.AuthHandler.generateOneTimeLoginToken.yields(
@@ -176,14 +161,10 @@ describe('AuthController', function() {
         expect(template).to.equal('one-time-login-request-form')
         expect(vars.email).to.equal(email)
         expect(vars.error).to.exist
-        return done()
+        done()
       })
 
-      return this.AuthController.oneTimeLoginRequest(
-        this.req,
-        this.res,
-        this.next
-      )
+      this.AuthController.oneTimeLoginRequest(this.req, this.res, this.next)
     })
   })
 })

--- a/test/unit/js/AuthControllerTests.js
+++ b/test/unit/js/AuthControllerTests.js
@@ -40,7 +40,8 @@ describe('AuthController', function() {
     }
     this.res = {
       redirect: sinon.stub(),
-      render: sinon.stub()
+      render: sinon.stub(),
+      status: sinon.stub().returnsThis()
     }
     this.next = sinon.stub()
   })
@@ -70,6 +71,7 @@ describe('AuthController', function() {
   describe('handleLoginErrors', () =>
     it('rerenders the login screen on authentication failure', function(done) {
       this.res.render.callsFake((template, vars) => {
+        expect(this.res.status).to.have.been.calledWith(400)
         expect(template).to.equal('home')
         expect(vars).to.deep.equal({ failedLogin: true })
         done()
@@ -119,6 +121,7 @@ describe('AuthController', function() {
   describe('handleOneTimeLoginErrors', () =>
     it('rerenders the login screen on authentication failure', function(done) {
       this.res.render.callsFake((template, vars) => {
+        expect(this.res.status).to.have.been.calledWith(400)
         expect(template).to.equal('home')
         expect(vars).to.deep.equal({ failedOneTimeLogin: true })
         done()
@@ -158,6 +161,7 @@ describe('AuthController', function() {
         new Errors.UserNotFoundError()
       )
       this.res.render.callsFake((template, vars) => {
+        expect(this.res.status).to.have.been.calledWith(400)
         expect(template).to.equal('one-time-login-request-form')
         expect(vars.email).to.equal(email)
         expect(vars.error).to.exist


### PR DESCRIPTION
### Description

Add a rate limit (by IP) to the following endpoints:

* POST /login
* POST /one-time-login
* POST /one-time-login/request

Allow 10 requests per minute

#### Related Issues / PRs

* https://github.com/overleaf/google-ops/issues/334

### Review

The first commit is a decaffeinate cleanup.

I used the [express-rate-limit](https://github.com/nfriedly/express-rate-limit) package instead of our [fork of rolling-update-limiter](https://github.com/ShaneKilkelly/rolling-rate-limiter) as used in web because I preferred a package that was published on npm and I didn't need the precision of rolling windows.

The rate limiter uses a global fixed window, i.e. [hit counts are all reset every minute](https://github.com/nfriedly/express-rate-limit/blob/master/lib/memory-store.js#L42). That seemed sufficient to me, but you might disagree. On the other hand, it's simpler and probably faster and less memory intensive.

#### Manual Testing Performed

- [x] Try to login repeatedly, see the rate limit message, wait a bit, try to login again
- [x] Do the same with one-time login request
- [x] Do the same with one-time login