### PR TITLE
Refer to status page and mention limitations

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,10 @@ function startApp(host, port, callback) {
     app.use(fixForwardedForHeaders)
   }
 
+  app.locals.settings = {
+    statusPageUrl: Settings.statusPageUrl
+  }
+
   Router.initialize(app)
   Metrics.initialize('read-only')
   logger.initialize('read-only')

--- a/app/views/layout.pug
+++ b/app/views/layout.pug
@@ -9,6 +9,11 @@ html
 body.content-alt
 	.container(style="margin-top: 12px")
 		.row
-				.col-md-10.col-md-offset-1
-						.card Overleaf is in read only mode while we perform planned maintenance.
+				.col-md-10.col-md-offset-1.text-center
+						p.card Overleaf is in read only mode while we perform maintenance. Please check our #[a(href=settings.statusPageUrl) status page] for updates.
 	block content
+	.container(style="margin-top: 3em;")
+		.row
+				.col-md-6.col-md-offset-3.text-center
+					p
+						small You can access the latest available backups of your projects here while Overleaf is down for maintenance. Please note that the data here may be several hours old; the latest changes to your projects and accounts will be accessible once maintenance is complete.

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -75,5 +75,7 @@ module.exports = {
     email: process.env['SMOKE_TEST_EMAIL'],
     password: process.env['SMOKE_TEST_PASSWORD'],
     projectId: process.env['SMOKE_TEST_PROJECT_ID']
-  }
+  },
+
+  statusPageUrl: process.env['STATUS_PAGE_URL'] || 'http://status.overleaf.com'
 }


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Based on changes in web in https://github.com/overleaf/web-internal/pull/2078, I thought I'd make the wording on the read only site consistent.

I also added a rider that explains that the data here may be stale. I think "several hours" is a bit conservative, but I figure it is better to be conservative here.

#### Screenshots

Current:

![image](https://user-images.githubusercontent.com/160829/63012333-f612da00-be81-11e9-82f2-c19d697a4ed6.png)

New:

![image](https://user-images.githubusercontent.com/160829/63012297-e72c2780-be81-11e9-8174-6c776abfe570.png)

#### Related Issues / PRs

- https://github.com/overleaf/google-ops/issues/329 - requested changes in web
- https://github.com/overleaf/web-internal/pull/2078

### Review

- I've added a config var for `statusPageUrl`, like in web, but in web it's only the hostname, and here it's the full URL. I think the name suggests it is a full URL, so I've gone with that interpretation here, but it is inconsistent.

#### Potential Impact

Wording only.

#### Manual Testing Performed

- [x] load the read-only.dev-overleaf.com front page (PR incoming on dev environment to make that possible)

#### Accessibility

- The 'fine print' is a bit small but hopefully still legible (bootstrap default).

### Deployment

No special concerns.

#### Who Needs to Know?

- @henryoswald 
- @mans0954 
- @emcsween 