### PR TITLE
[misc] bump logger-sharelatex to 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4739,9 +4739,9 @@
       }
     },
     "logger-sharelatex": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/logger-sharelatex/-/logger-sharelatex-1.9.0.tgz",
-      "integrity": "sha512-yVTuha82047IiMOQLgQHCZGKkJo6I2+2KtiFKpgkIooR2yZaoTEvAeoMwBesSDSpGUpvUJ/+9UI+PmRyc+PQKQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/logger-sharelatex/-/logger-sharelatex-1.9.1.tgz",
+      "integrity": "sha512-9s6JQnH/PN+Js2CmI8+J3MQCTNlRzP2Dh4pcekXrV6Jm5J4HzyPi+6d3zfBskZ4NBmaUVw9hC4p5dmdaRmh4mQ==",
       "requires": {
         "@google-cloud/logging-bunyan": "^2.0.0",
         "@overleaf/o-error": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express-rate-limit": "^5.1.1",
     "express-session": "^1.17.0",
     "lodash": "^4.17.15",
-    "logger-sharelatex": "^1.9.0",
+    "logger-sharelatex": "^1.9.1",
     "marked": "^0.8.0",
     "metrics-sharelatex": "^2.5.0",
     "mongodb": "^3.5.4",


### PR DESCRIPTION
### Description

Update logger-sharelatex from 1.9.0 to 1.9.1.


#### Related Issues / PRs

https://github.com/overleaf/logger-module/pull/17


#### Potential Impact

Low.
